### PR TITLE
refactor: merge register and authenticate

### DIFF
--- a/proto/ratings_features_user.proto
+++ b/proto/ratings_features_user.proto
@@ -6,19 +6,11 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 
 service User {
-  rpc Register (RegisterRequest) returns (RegisterResponse) {}
   rpc Authenticate (AuthenticateRequest) returns (AuthenticateResponse) {}
+
   rpc Delete (google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc Vote (VoteRequest) returns (google.protobuf.Empty) {}
   rpc ListMyVotes (ListMyVotesRequest) returns (ListMyVotesResponse) {}
-}
-
-message RegisterRequest {
-  string id = 1;
-}
-
-message RegisterResponse {
-  string token = 1;
 }
 
 message AuthenticateRequest {

--- a/src/features/user/errors.rs
+++ b/src/features/user/errors.rs
@@ -2,8 +2,6 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum UserError {
-    #[error("invalid user id")]
-    InvalidUserId,
     #[error("failed to create user record")]
     FailedToCreateUserRecord,
     #[error("failed to delete user by instance id")]

--- a/src/features/user/use_cases.rs
+++ b/src/features/user/use_cases.rs
@@ -1,17 +1,13 @@
 use crate::app::AppContext;
-use crate::features::user::infrastructure::{find_user_votes, save_vote_to_db, user_seen};
+use crate::features::user::infrastructure::{find_user_votes, save_vote_to_db};
 
 use super::entities::{User, Vote};
 use super::errors::UserError;
-use super::infrastructure::{create_user_in_db, delete_user_by_client_hash};
+use super::infrastructure::{create_or_seen_user, delete_user_by_client_hash};
 
-pub async fn register(app_ctx: &AppContext, client_hash: &str) -> Result<User, UserError> {
-    let user = User::new(client_hash);
-    create_user_in_db(app_ctx, user).await
-}
-
-pub async fn authenticate(app_ctx: &AppContext, id: &str) -> Result<bool, UserError> {
-    user_seen(app_ctx, id).await
+pub async fn authenticate(app_ctx: &AppContext, id: &str) -> Result<User, UserError> {
+    let user = User::new(id);
+    create_or_seen_user(app_ctx, user).await
 }
 
 pub async fn delete_user(app_ctx: &AppContext, client_hash: &str) -> Result<(), UserError> {

--- a/tests/app_tests/lifecycle_test.rs
+++ b/tests/app_tests/lifecycle_test.rs
@@ -9,7 +9,7 @@ use crate::helpers::test_data::TestData;
 use crate::helpers::vote_generator::generate_votes;
 use crate::helpers::{self, client_app::pb::RatingsBand, client_app::AppClient};
 use crate::helpers::{
-    client_user::{pb::RegisterResponse, UserClient},
+    client_user::{pb::AuthenticateResponse, UserClient},
     data_faker,
 };
 
@@ -54,7 +54,7 @@ async fn vote_once(mut data: TestData) -> TestData {
     data.id = Some(id.to_string());
 
     let client = data.user_client.clone().unwrap();
-    let response: RegisterResponse = client.register(&id).await.unwrap().into_inner();
+    let response: AuthenticateResponse = client.authenticate(&id).await.unwrap().into_inner();
     let token: String = response.token;
     data.token = Some(token.to_string());
 

--- a/tests/helpers/client_user.rs
+++ b/tests/helpers/client_user.rs
@@ -1,8 +1,6 @@
 use tonic::metadata::MetadataValue;
 use tonic::transport::Endpoint;
 use tonic::{Request, Response, Status};
-use tracing::info;
-
 pub mod pb {
     pub use self::user_client::UserClient;
 
@@ -19,14 +17,6 @@ impl UserClient {
         Self {
             url: format!("http://{socket}/"),
         }
-    }
-
-    pub async fn register(&self, id: &str) -> Result<Response<pb::RegisterResponse>, Status> {
-        info!("URL: {:?}", self.url.clone());
-        let mut client = pb::UserClient::connect(self.url.clone()).await.unwrap();
-        client
-            .register(pb::RegisterRequest { id: id.to_string() })
-            .await
     }
 
     #[allow(dead_code)]

--- a/tests/helpers/vote_generator.rs
+++ b/tests/helpers/vote_generator.rs
@@ -1,4 +1,4 @@
-use super::super::helpers::client_user::pb::{AuthenticateResponse, RegisterResponse, VoteRequest};
+use super::super::helpers::client_user::pb::{AuthenticateResponse, VoteRequest};
 use super::test_data::TestData;
 use crate::helpers;
 
@@ -23,8 +23,8 @@ async fn register_and_vote(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let client = data.user_client.clone().unwrap();
     let id: String = helpers::data_faker::rnd_sha_256();
-    let response: RegisterResponse = client
-        .register(&id)
+    let response: AuthenticateResponse = client
+        .authenticate(&id)
         .await
         .expect("register request should succeed")
         .into_inner();

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,4 +1,5 @@
 mod user_tests {
+    mod double_authenticate_test;
     mod reject_invalid_register_test;
     mod simple_lifecycle_test;
 }

--- a/tests/user_tests/double_authenticate_test.rs
+++ b/tests/user_tests/double_authenticate_test.rs
@@ -1,0 +1,79 @@
+use crate::helpers;
+use crate::helpers::test_data::TestData;
+
+use super::super::helpers::client_user::pb::AuthenticateResponse;
+use super::super::helpers::client_user::UserClient;
+use super::super::helpers::with_lifecycle::with_lifecycle;
+use ratings::app::AppContext;
+use ratings::utils::{self, Infrastructure};
+use sqlx::Row;
+use utils::Config;
+
+#[tokio::test]
+async fn authenticate_twice_test() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::load()?;
+    let infra = Infrastructure::new(&config).await?;
+    let app_ctx = AppContext::new(&config, infra);
+
+    let data = TestData {
+        user_client: Some(UserClient::new(&config.socket())),
+        app_ctx,
+        id: None,
+        token: None,
+        app_client: None,
+        snap_id: None,
+    };
+
+    with_lifecycle(async {
+        double_authenticate(data.clone()).await;
+    })
+    .await;
+    Ok(())
+}
+
+async fn double_authenticate(data: TestData) {
+    let id: String = helpers::data_faker::rnd_sha_256();
+    let client = data.user_client.clone().unwrap();
+
+    // First authenticate, registers user
+    let response: AuthenticateResponse = client
+        .authenticate(&id)
+        .await
+        .expect("authentication request should succeed")
+        .into_inner();
+
+    let first_token: String = response.token;
+    helpers::assert::assert_token_is_valid(&first_token, &data.app_ctx.config().jwt_secret);
+
+    let mut conn = data.repository().await.unwrap();
+    let rows = sqlx::query("SELECT * FROM users WHERE client_hash = $1")
+        .bind(&id)
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+
+    let actual: String = rows.get("client_hash");
+    assert_eq!(actual, id);
+
+    // Second authenticate
+    let response: AuthenticateResponse = client
+        .authenticate(&id)
+        .await
+        .expect("authentication request should succeed")
+        .into_inner();
+
+    let second_token: String = response.token;
+    helpers::assert::assert_token_is_valid(&second_token, &data.app_ctx.config().jwt_secret);
+
+    // User still registered
+    let row = sqlx::query("SELECT COUNT(*) FROM users WHERE client_hash = $1")
+        .bind(&id)
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+
+    let count: i64 = row.try_get("count").expect("Failed to get count");
+
+    // Only appears in db once
+    assert_eq!(count, 1);
+}

--- a/tests/user_tests/reject_invalid_register_test.rs
+++ b/tests/user_tests/reject_invalid_register_test.rs
@@ -11,7 +11,7 @@ async fn blank() -> Result<(), Box<dyn std::error::Error>> {
         let id = "";
         let client = UserClient::new(&config.socket());
 
-        match client.register(id).await {
+        match client.authenticate(id).await {
             Ok(response) => panic!("expected Err but got Ok: {response:?}"),
             Err(status) => {
                 assert_eq!(status.code(), Code::InvalidArgument)
@@ -30,7 +30,7 @@ async fn wrong_length() -> Result<(), Box<dyn std::error::Error>> {
         let client_hash = "foobarbazbun";
         let client = UserClient::new(&config.socket());
 
-        match client.register(client_hash).await {
+        match client.authenticate(client_hash).await {
             Ok(response) => panic!("expected Err but got Ok: {response:?}"),
             Err(status) => {
                 assert_eq!(status.code(), Code::InvalidArgument)


### PR DESCRIPTION
Moved to using upsert for the time being to simplify auth flow for app-center for the mvp release:
- if the user hash doesn't exist, registers user and returns JWT
- else updates their last seen and returns a fresh JWT

When we have time and come back to implement refresh tokens we can rework this.