### PR TITLE
feat: added GetSnapVotes endpoint

### DIFF
--- a/proto/ratings_features_user.proto
+++ b/proto/ratings_features_user.proto
@@ -11,6 +11,7 @@ service User {
   rpc Delete (google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc Vote (VoteRequest) returns (google.protobuf.Empty) {}
   rpc ListMyVotes (ListMyVotesRequest) returns (ListMyVotesResponse) {}
+  rpc GetSnapVotes(GetSnapVotesRequest) returns (GetSnapVotesResponse) {}
 }
 
 message AuthenticateRequest {
@@ -26,6 +27,14 @@ message ListMyVotesRequest {
 }
 
 message ListMyVotesResponse {
+  repeated Vote votes = 1;
+}
+
+message GetSnapVotesRequest {
+  string snap_id = 1;
+}
+
+message GetSnapVotesResponse {
   repeated Vote votes = 1;
 }
 

--- a/src/features/user/errors.rs
+++ b/src/features/user/errors.rs
@@ -6,6 +6,8 @@ pub enum UserError {
     FailedToCreateUserRecord,
     #[error("failed to delete user by instance id")]
     FailedToDeleteUserRecord,
+    #[error("failed to get user vote")]
+    FailedToGetUserVote,
     #[error("failed to cast vote")]
     FailedToCastVote,
     #[error("unknown user error")]

--- a/src/features/user/use_cases.rs
+++ b/src/features/user/use_cases.rs
@@ -3,7 +3,9 @@ use crate::features::user::infrastructure::{find_user_votes, save_vote_to_db};
 
 use super::entities::{User, Vote};
 use super::errors::UserError;
-use super::infrastructure::{create_or_seen_user, delete_user_by_client_hash};
+use super::infrastructure::{
+    create_or_seen_user, delete_user_by_client_hash, get_snap_votes_by_client_hash,
+};
 
 pub async fn authenticate(app_ctx: &AppContext, id: &str) -> Result<User, UserError> {
     let user = User::new(id);
@@ -20,6 +22,14 @@ pub async fn vote(app_ctx: &AppContext, vote: Vote) -> Result<(), UserError> {
     let result = save_vote_to_db(app_ctx, vote).await;
     result?;
     Ok(())
+}
+
+pub async fn get_snap_votes(
+    app_ctx: &AppContext,
+    snap_id: String,
+    client_hash: String,
+) -> Result<Vec<Vote>, UserError> {
+    get_snap_votes_by_client_hash(app_ctx, snap_id, client_hash).await
 }
 
 pub async fn list_my_votes(

--- a/tests/helpers/client_user.rs
+++ b/tests/helpers/client_user.rs
@@ -1,6 +1,8 @@
 use tonic::metadata::MetadataValue;
 use tonic::transport::Endpoint;
 use tonic::{Request, Response, Status};
+
+use self::pb::GetSnapVotesResponse;
 pub mod pb {
     pub use self::user_client::UserClient;
 
@@ -43,6 +45,25 @@ impl UserClient {
             Ok(req)
         });
         client.vote(ballet).await
+    }
+
+    #[allow(dead_code)]
+    pub async fn get_snap_votes(
+        &self,
+        token: &str,
+        request: pb::GetSnapVotesRequest,
+    ) -> Result<Response<GetSnapVotesResponse>, Status> {
+        let channel = Endpoint::from_shared(self.url.clone())
+            .unwrap()
+            .connect()
+            .await
+            .unwrap();
+        let mut client = pb::UserClient::with_interceptor(channel, move |mut req: Request<()>| {
+            let header: MetadataValue<_> = format!("Bearer {token}").parse().unwrap();
+            req.metadata_mut().insert("authorization", header);
+            Ok(req)
+        });
+        client.get_snap_votes(request).await
     }
 
     #[allow(dead_code)]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,5 +1,6 @@
 mod user_tests {
     mod double_authenticate_test;
+    mod get_votes_lifecycle_test;
     mod reject_invalid_register_test;
     mod simple_lifecycle_test;
 }

--- a/tests/user_tests/get_votes_lifecycle_test.rs
+++ b/tests/user_tests/get_votes_lifecycle_test.rs
@@ -1,0 +1,190 @@
+use crate::helpers;
+use crate::helpers::client_user::pb::GetSnapVotesRequest;
+use crate::helpers::test_data::TestData;
+
+use super::super::helpers::client_user::pb::{AuthenticateResponse, VoteRequest};
+use super::super::helpers::client_user::UserClient;
+use super::super::helpers::with_lifecycle::with_lifecycle;
+use futures::FutureExt;
+use ratings::app::AppContext;
+use ratings::utils::{self, Infrastructure};
+use sqlx::Row;
+
+use utils::Config;
+
+#[tokio::test]
+async fn get_votes_lifecycle_test() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::load()?;
+    let infra = Infrastructure::new(&config).await?;
+    let app_ctx = AppContext::new(&config, infra);
+
+    let data = TestData {
+        user_client: Some(UserClient::new(&config.socket())),
+        app_ctx,
+        id: None,
+        token: None,
+        app_client: None,
+        snap_id: None,
+    };
+
+    with_lifecycle(async {
+        authenticate(data.clone())
+            .then(cast_vote)
+            .then(get_votes)
+            .await;
+    })
+    .await;
+    Ok(())
+}
+
+async fn authenticate(mut data: TestData) -> TestData {
+    let id: String = helpers::data_faker::rnd_sha_256();
+    data.id = Some(id.to_string());
+
+    let client = data.user_client.clone().unwrap();
+    let response: AuthenticateResponse = client
+        .authenticate(&id)
+        .await
+        .expect("authentication request should succeed")
+        .into_inner();
+
+    let token: String = response.token;
+    data.token = Some(token.to_string());
+    helpers::assert::assert_token_is_valid(&token, &data.app_ctx.config().jwt_secret);
+
+    let mut conn = data.repository().await.unwrap();
+
+    let rows = sqlx::query("SELECT * FROM users WHERE client_hash = $1")
+        .bind(&id)
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+
+    let actual: String = rows.get("client_hash");
+
+    assert_eq!(actual, id);
+
+    data
+}
+
+async fn cast_vote(data: TestData) -> TestData {
+    let id = data.id.clone().unwrap();
+    let token = data.token.clone().unwrap();
+    let client = data.user_client.clone().unwrap();
+
+    let expected_snap_id = "r4LxMVp7zWramXsJQAKdamxy6TAWlaDD";
+    let expected_snap_revision = 111;
+    let expected_vote_up = true;
+
+    let ballet = VoteRequest {
+        snap_id: expected_snap_id.to_string(),
+        snap_revision: expected_snap_revision,
+        vote_up: expected_vote_up,
+    };
+
+    client
+        .vote(&token, ballet)
+        .await
+        .expect("vote should succeed")
+        .into_inner();
+
+    let mut conn = data.repository().await.unwrap();
+
+    let result = sqlx::query(
+        r#"
+        SELECT votes.*
+        FROM votes
+        JOIN users ON votes.user_id_fk = users.id
+        WHERE users.client_hash = $1 AND votes.snap_id = $2 AND votes.snap_revision = $3;
+    "#,
+    )
+    .bind(&id)
+    .bind(expected_snap_id)
+    .bind(expected_snap_revision)
+    .fetch_one(&mut *conn)
+    .await
+    .unwrap();
+
+    let actual_snap_id: String = result.try_get("snap_id").unwrap();
+    let actual_snap_revision: i32 = result.try_get("snap_revision").unwrap();
+    let actual_vote_up: bool = result.try_get("vote_up").unwrap();
+
+    assert_eq!(actual_snap_id, expected_snap_id);
+    assert_eq!(actual_snap_revision, expected_snap_revision);
+    assert_eq!(actual_vote_up, expected_vote_up);
+
+    let expected_snap_id = "r4LxMVp7zWramXsJQAKdamxy6TAWlaDD";
+    let expected_snap_revision = 112;
+    let expected_vote_up = false;
+
+    let ballet = VoteRequest {
+        snap_id: expected_snap_id.to_string(),
+        snap_revision: expected_snap_revision,
+        vote_up: expected_vote_up,
+    };
+
+    client
+        .vote(&token, ballet)
+        .await
+        .expect("vote should succeed")
+        .into_inner();
+
+    let result = sqlx::query(
+        r#"
+        SELECT votes.*
+        FROM votes
+        JOIN users ON votes.user_id_fk = users.id
+        WHERE users.client_hash = $1 AND votes.snap_id = $2 AND votes.snap_revision = $3;
+    "#,
+    )
+    .bind(&id)
+    .bind(expected_snap_id)
+    .bind(expected_snap_revision)
+    .fetch_one(&mut *conn)
+    .await
+    .unwrap();
+
+    let actual_snap_id: String = result.try_get("snap_id").unwrap();
+    let actual_snap_revision: i32 = result.try_get("snap_revision").unwrap();
+    let actual_vote_up: bool = result.try_get("vote_up").unwrap();
+
+    assert_eq!(actual_snap_id, expected_snap_id);
+    assert_eq!(actual_snap_revision, expected_snap_revision);
+    assert_eq!(actual_vote_up, expected_vote_up);
+
+    data
+}
+
+async fn get_votes(data: TestData) -> TestData {
+    let token = data.token.clone().unwrap();
+    let client = data.user_client.clone().unwrap();
+
+    let expected_snap_id = "r4LxMVp7zWramXsJQAKdamxy6TAWlaDD".to_string();
+    let expected_first_revision = 111;
+    let expected_first_vote_up = true;
+    let expected_second_revision = 112;
+    let expected_second_vote_up = false;
+
+    let request = GetSnapVotesRequest {
+        snap_id: expected_snap_id.clone(),
+    };
+    let votes = client
+        .get_snap_votes(&token, request)
+        .await
+        .expect("get votes should succeed")
+        .into_inner()
+        .votes;
+
+    let actual_snap_id = &votes[0].snap_id;
+    let actual_first_revision = votes[0].snap_revision;
+    let actual_first_vote_up = votes[0].vote_up;
+    let actual_second_revision = votes[1].snap_revision;
+    let actual_second_vote_up = votes[1].vote_up;
+
+    assert_eq!(actual_snap_id, &expected_snap_id);
+    assert_eq!(actual_first_revision, expected_first_revision);
+    assert_eq!(actual_first_vote_up, expected_first_vote_up);
+    assert_eq!(actual_second_vote_up, expected_second_vote_up);
+    assert_eq!(actual_second_revision, expected_second_revision);
+    data
+}


### PR DESCRIPTION
Returns all votes a user has cast against a specific `snap_id` for various snap_revisions

Chatted to Dennis and he feels that for the time being getting the users votes against a snap on demand when we load the details page is better than trying to cache and manage vote state for MVP.

Undecided on the endpoint name. Not sure if `GetVotes` is more concise but ambiguous what the difference between that and `ListMyVotes`? WDYT?