### PR TITLE
Rockcraft update

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,5 +1,5 @@
 name: ratings
-version: 0.0.1
+version: 0.0.4
 license: GPL-3.0
 
 base: bare
@@ -45,3 +45,9 @@ parts:
       - libc6_libs
       - libgcc-s1_libs
       - ca-certificates_data
+
+  migrations:
+    plugin: dump
+    source: ./sql/
+    organize:
+        migrations : sql/migrations

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -27,13 +27,13 @@ services:
     command: "/bin/ratings"
 
 parts:
-  rust-deps:
+  rust-dependencies:
     plugin: nil
     override-pull: |
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
 
   ratings:
-    after: [ rust-deps ]
+    after: [ rust-dependencies ]
     plugin: rust
     build-packages:
       - libssl-dev

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,3 @@
-
-
-
-
 mod app;
 mod features;
 mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
-use std::env;
 
-use tracing::info;
+
+
 
 mod app;
 mod features;


### PR DESCRIPTION
Changes to rockcraft.yaml to get it working with updated ratings requirements
- bug workaround when using parts named rust-deps
- dump migrations next to bin
- ran the linter and removed unused imports

There changes are required for the [changes](https://github.com/canonical/app-center-ratings-k8s-operator/pull/4) to the k8s operator