### PR TITLE
fix(main): make use of config log-level value

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,16 @@ mod utils;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = utils::Config::load()?;
 
+    let log_level = match config.log_level.as_str() {
+        "debug" => tracing::Level::DEBUG,
+        "info" => tracing::Level::INFO,
+        "warn" => tracing::Level::WARN,
+        "error" => tracing::Level::ERROR,
+        _ => tracing::Level::INFO,
+    };
+
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
+        .with_max_level(log_level)
         .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
         .init();
 


### PR DESCRIPTION
We never end up using the log level set in the .env / snap_env. This change adds that in. 