### PR TITLE
feat: getChart

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: Build and test
 
 on:
   workflow_call:
@@ -36,14 +36,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
 
-      - name: Build binary
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all-features
+      # - name: Build binary
+      #   uses: actions-rs/cargo@v1
+      #   with:
+      #     command: build
+      #     args: --release --all-features
 
-      - name: Upload binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: ratings
-          path: target/release/ratings
+      # - name: Upload binary
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: ratings
+      #     path: target/release/ratings
+
+      - name: Setup and Run Tests
+        run: |
+          cp example.env .env
+          cargo install cargo-make
+          cargo make db-up
+          cargo make full-test

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -11,6 +11,6 @@ concurrency:
 
 jobs:
   build:
-    uses: ./.github/workflows/build.yaml
+    uses: ./.github/workflows/build-and-test.yaml
   cla:
     uses: ./.github/workflows/cla.yaml

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,4 +11,4 @@ concurrency:
 
 jobs:
   build:
-    uses: ./.github/workflows/build.yaml
+    uses: ./.github/workflows/build-and-test.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build/
 .coverage
 __pycache__/
 *.py[cod]
+server.pid

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.rock
 *.nix
 
-proto/*.rs
+/proto/*.rs
 venv/
 build/
 *.charm

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.rock
 *.nix
 
+proto/*.rs
 venv/
 build/
 *.charm

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,10 @@
+use std::path::Path;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Define the path to the output directory within the `src` folder
+    let out_dir = Path::new("proto");
+    std::fs::create_dir_all(out_dir)?;
+
     let descriptor_set_path = format!(
         "{}/ratings_descriptor.bin",
         std::env::var("OUT_DIR").unwrap()
@@ -14,6 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_server(true)
         .file_descriptor_set_path(descriptor_set_path)
+        .out_dir(out_dir)
         .compile(files, &["proto"])?;
 
     Ok(())

--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "proto/ratings_features_app.proto",
         "proto/ratings_features_chart.proto",
         "proto/ratings_features_user.proto",
+        "proto/ratings_features_common.proto",
     ];
 
     tonic_build::configure()

--- a/example.env
+++ b/example.env
@@ -1,7 +1,7 @@
 APP_ENV=dev
 APP_HOST=0.0.0.0
 APP_JWT_SECRET=deadbeef
-APP_LOG_LEVEL=info
+APP_LOG_LEVEL=error
 APP_NAME=ratings
 APP_PORT=8080
 # Update this with some real PostgreSQL details

--- a/proto/ratings_features_app.proto
+++ b/proto/ratings_features_app.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package ratings.features.app;
 
+import "ratings_features_common.proto";
+
 service App {
   rpc GetRating (GetRatingRequest) returns (GetRatingResponse) {}
 }
@@ -11,20 +13,5 @@ message GetRatingRequest {
 }
 
 message GetRatingResponse {
-  Rating rating = 1;
-}
-
-message Rating {
-  string snap_id = 1;
-  uint64 total_votes = 2;
-  RatingsBand ratings_band = 3;
-}
-
-enum RatingsBand {
-  VERY_GOOD = 0;
-  GOOD = 1;
-  NEUTRAL = 2;
-  POOR = 3;
-  VERY_POOR = 4;
-  INSUFFICIENT_VOTES = 5;
+  ratings.features.common.Rating rating = 1;
 }

--- a/proto/ratings_features_chart.proto
+++ b/proto/ratings_features_chart.proto
@@ -8,28 +8,32 @@ service Chart {
 
 message GetChartRequest {
   Timeframe timeframe = 1;
-  ChartType type = 2;
-}
-
-enum ChartType {
-  CHART_TYPE_TOP_UNSPECIFIED = 0;
-  CHART_TYPE_TOP = 1;
 }
 
 message GetChartResponse {
   Timeframe timeframe = 1;
-  ChartType type = 2;
-  repeated ChartData ordered_chart_data = 3;
+  repeated ChartData ordered_chart_data = 2;
 }
 
 message ChartData {
   string app = 1;
   uint64 total_up_votes = 2;
   uint64 total_down_votes = 3;
+  float rating = 4;
+  RatingsBand rating_band = 5;
 }
 
 enum Timeframe {
   TIMEFRAME_UNSPECIFIED = 0;
   TIMEFRAME_WEEK = 1;
   TIMEFRAME_MONTH = 2;
+}
+
+enum RatingsBand {
+  VERY_GOOD = 0;
+  GOOD = 1;
+  NEUTRAL = 2;
+  POOR = 3;
+  VERY_POOR = 4;
+  INSUFFICIENT_VOTES = 5;
 }

--- a/proto/ratings_features_chart.proto
+++ b/proto/ratings_features_chart.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package ratings.features.chart;
 
+import "ratings_features_common.proto";
+
 service Chart {
   rpc GetChart (GetChartRequest) returns (GetChartResponse) {}
 }
@@ -16,24 +18,12 @@ message GetChartResponse {
 }
 
 message ChartData {
-  string app = 1;
-  uint64 total_up_votes = 2;
-  uint64 total_down_votes = 3;
-  float rating = 4;
-  RatingsBand rating_band = 5;
+  float raw_rating = 1;
+  ratings.features.common.Rating rating = 2;
 }
 
 enum Timeframe {
   TIMEFRAME_UNSPECIFIED = 0;
   TIMEFRAME_WEEK = 1;
   TIMEFRAME_MONTH = 2;
-}
-
-enum RatingsBand {
-  VERY_GOOD = 0;
-  GOOD = 1;
-  NEUTRAL = 2;
-  POOR = 3;
-  VERY_POOR = 4;
-  INSUFFICIENT_VOTES = 5;
 }

--- a/proto/ratings_features_common.proto
+++ b/proto/ratings_features_common.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package ratings.features.common;
+
+message Rating {
+  string snap_id = 1;
+  uint64 total_votes = 2;
+  RatingsBand ratings_band = 3;
+}
+
+enum RatingsBand {
+  VERY_GOOD = 0;
+  GOOD = 1;
+  NEUTRAL = 2;
+  POOR = 3;
+  VERY_POOR = 4;
+  INSUFFICIENT_VOTES = 5;
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: ratings
 base: core22
-version: '1.6'
+version: '1.8'
 license: GPL-3.0
 summary: Ubuntu App Ratings Service
 description: |

--- a/src/app/interfaces/authentication.rs
+++ b/src/app/interfaces/authentication.rs
@@ -2,8 +2,7 @@ use http::header;
 use tonic::{Request, Status};
 use tracing::error;
 
-use crate::app::context::AppContext;
-use crate::app::RequestContext;
+use crate::app::{context::AppContext, RequestContext};
 
 pub fn authentication(req: Request<()>) -> Result<Request<()>, Status> {
     let app_ctx = req.extensions().get::<AppContext>().unwrap().clone();

--- a/src/app/interfaces/middleware.rs
+++ b/src/app/interfaces/middleware.rs
@@ -1,7 +1,6 @@
 use std::pin::Pin;
 
-use hyper::service::Service;
-use hyper::Body;
+use hyper::{service::Service, Body};
 use tonic::body::BoxBody;
 use tower::Layer;
 

--- a/src/app/interfaces/routes.rs
+++ b/src/app/interfaces/routes.rs
@@ -1,7 +1,7 @@
 use tonic::transport::server::Router;
 use tonic_reflection::server::ServerReflection;
 
-use crate::features::{app, user};
+use crate::features::{app, chart, user};
 
 pub fn build_reflection_service(
 ) -> tonic_reflection::server::ServerReflectionServer<impl ServerReflection> {
@@ -16,6 +16,10 @@ pub fn build_reflection_service(
 pub fn build_servers<R>(router: Router<R>) -> Router<R> {
     let user_service = user::service::build_service();
     let app_service = app::service::build_service();
+    let chart_service = chart::service::build_service();
 
-    router.add_service(user_service).add_service(app_service)
+    router
+        .add_service(user_service)
+        .add_service(app_service)
+        .add_service(chart_service)
 }

--- a/src/features/app/infrastructure.rs
+++ b/src/features/app/infrastructure.rs
@@ -1,5 +1,5 @@
 use crate::{app::AppContext, features::common::entities::VoteSummary};
-use tracing::error;
+use tracing::{error, info};
 
 use super::errors::AppError;
 
@@ -17,10 +17,9 @@ pub(crate) async fn get_votes_by_snap_id(
         })?;
 
     let result = sqlx::query_as::<_, VoteSummary>(
-        // Changed to query_as with VoteSummary
         r#"
             SELECT
-                $1 as snap_id, // Explicitly select snap_id since it's not part of the GROUP BY
+                votes.snap_id,
                 COUNT(*) AS total_votes,
                 COUNT(*) FILTER (WHERE votes.vote_up) AS positive_votes
             FROM
@@ -31,7 +30,7 @@ pub(crate) async fn get_votes_by_snap_id(
         "#,
     )
     .bind(snap_id)
-    .fetch_one(&mut *pool) // Changed to fetch_one since we're expecting a single summarized row
+    .fetch_one(&mut *pool)
     .await
     .map_err(|error| {
         error!("{error:?}");

--- a/src/features/app/infrastructure.rs
+++ b/src/features/app/infrastructure.rs
@@ -1,5 +1,4 @@
-use crate::{app::AppContext, features::common::entities::Vote};
-use sqlx::Row;
+use crate::{app::AppContext, features::common::entities::VoteSummary};
 use tracing::error;
 
 use super::errors::AppError;
@@ -7,7 +6,7 @@ use super::errors::AppError;
 pub(crate) async fn get_votes_by_snap_id(
     app_ctx: &AppContext,
     snap_id: &str,
-) -> Result<Vec<Vote>, AppError> {
+) -> Result<VoteSummary, AppError> {
     let mut pool = app_ctx
         .infrastructure()
         .repository()
@@ -16,32 +15,28 @@ pub(crate) async fn get_votes_by_snap_id(
             error!("{error:?}");
             AppError::FailedToGetRating
         })?;
-    let result = sqlx::query(
+
+    let result = sqlx::query_as::<_, VoteSummary>(
+        // Changed to query_as with VoteSummary
         r#"
-                SELECT
-                    votes.id,
-                    votes.snap_id,
-                    votes.vote_up
-                FROM
-                    votes
-                WHERE
-                    votes.snap_id = $1
-            "#,
+            SELECT
+                $1 as snap_id, // Explicitly select snap_id since it's not part of the GROUP BY
+                COUNT(*) AS total_votes,
+                COUNT(*) FILTER (WHERE votes.vote_up) AS positive_votes
+            FROM
+                votes
+            WHERE
+                votes.snap_id = $1
+            GROUP BY votes.snap_id
+        "#,
     )
     .bind(snap_id)
-    .fetch_all(&mut *pool)
+    .fetch_one(&mut *pool) // Changed to fetch_one since we're expecting a single summarized row
     .await
     .map_err(|error| {
         error!("{error:?}");
         AppError::Unknown
     })?;
 
-    let votes: Vec<Vote> = result
-        .into_iter()
-        .map(|row| Vote {
-            vote_up: row.get("vote_up"),
-        })
-        .collect();
-
-    Ok(votes)
+    Ok(result)
 }

--- a/src/features/app/infrastructure.rs
+++ b/src/features/app/infrastructure.rs
@@ -1,8 +1,8 @@
-use crate::app::AppContext;
+use crate::{app::AppContext, features::common::entities::Vote};
 use sqlx::Row;
 use tracing::error;
 
-use super::{entities::Vote, errors::AppError};
+use super::errors::AppError;
 
 pub(crate) async fn get_votes_by_snap_id(
     app_ctx: &AppContext,

--- a/src/features/app/infrastructure.rs
+++ b/src/features/app/infrastructure.rs
@@ -1,5 +1,5 @@
 use crate::{app::AppContext, features::common::entities::VoteSummary};
-use tracing::{error, info};
+use tracing::error;
 
 use super::errors::AppError;
 

--- a/src/features/app/infrastructure.rs
+++ b/src/features/app/infrastructure.rs
@@ -1,7 +1,8 @@
-use crate::{app::AppContext, features::common::entities::VoteSummary};
+use crate::{
+    app::AppContext,
+    features::{app::errors::AppError, common::entities::VoteSummary},
+};
 use tracing::error;
-
-use super::errors::AppError;
 
 pub(crate) async fn get_votes_by_snap_id(
     app_ctx: &AppContext,

--- a/src/features/app/interface.rs
+++ b/src/features/app/interface.rs
@@ -8,7 +8,7 @@ use super::{service::AppService, use_cases};
 
 pub mod protobuf {
     pub use self::app_server::App;
-
+    tonic::include_proto!("ratings.features.common");
     tonic::include_proto!("ratings.features.app");
 }
 

--- a/src/features/app/interface.rs
+++ b/src/features/app/interface.rs
@@ -1,11 +1,10 @@
 use crate::app::AppContext;
 
-use crate::features::pb::app::{GetRatingRequest, GetRatingResponse};
+use crate::features::{
+    app::{service::AppService, use_cases},
+    pb::app::{app_server::App, GetRatingRequest, GetRatingResponse},
+};
 use tonic::{Request, Response, Status};
-
-use crate::features::pb::app::app_server::App;
-
-use super::{service::AppService, use_cases};
 
 #[tonic::async_trait]
 impl App for AppService {

--- a/src/features/app/interface.rs
+++ b/src/features/app/interface.rs
@@ -1,16 +1,11 @@
 use crate::app::AppContext;
 
-use self::protobuf::{App, GetRatingRequest, GetRatingResponse};
-pub use protobuf::app_server;
+use crate::features::pb::app::{GetRatingRequest, GetRatingResponse};
 use tonic::{Request, Response, Status};
 
-use super::{service::AppService, use_cases};
+use crate::features::pb::app::app_server::App;
 
-pub mod protobuf {
-    pub use self::app_server::App;
-    tonic::include_proto!("ratings.features.common");
-    tonic::include_proto!("ratings.features.app");
-}
+use super::{service::AppService, use_cases};
 
 #[tonic::async_trait]
 impl App for AppService {

--- a/src/features/app/mod.rs
+++ b/src/features/app/mod.rs
@@ -1,4 +1,3 @@
-pub mod entities;
 mod errors;
 mod infrastructure;
 pub mod interface;

--- a/src/features/app/service.rs
+++ b/src/features/app/service.rs
@@ -1,4 +1,4 @@
-use super::interface::app_server::AppServer;
+use crate::features::pb::app::app_server::AppServer;
 
 #[derive(Debug, Default)]
 pub struct AppService;

--- a/src/features/app/use_cases.rs
+++ b/src/features/app/use_cases.rs
@@ -1,7 +1,11 @@
-use crate::{app::AppContext, features::common::entities::Rating};
+use crate::{
+    app::AppContext,
+    features::{
+        app::{errors::AppError, infrastructure::get_votes_by_snap_id},
+        common::entities::Rating,
+    },
+};
 use tracing::error;
-
-use super::{errors::AppError, infrastructure::get_votes_by_snap_id};
 
 pub async fn get_rating(app_ctx: &AppContext, snap_id: String) -> Result<Rating, AppError> {
     let votes = get_votes_by_snap_id(app_ctx, &snap_id)

--- a/src/features/app/use_cases.rs
+++ b/src/features/app/use_cases.rs
@@ -1,7 +1,7 @@
-use crate::app::AppContext;
+use crate::{app::AppContext, features::common::entities::Rating};
 use tracing::error;
 
-use super::{entities::Rating, errors::AppError, infrastructure::get_votes_by_snap_id};
+use super::{errors::AppError, infrastructure::get_votes_by_snap_id};
 
 pub async fn get_rating(app_ctx: &AppContext, snap_id: String) -> Result<Rating, AppError> {
     let votes = get_votes_by_snap_id(app_ctx, &snap_id)

--- a/src/features/app/use_cases.rs
+++ b/src/features/app/use_cases.rs
@@ -11,7 +11,7 @@ pub async fn get_rating(app_ctx: &AppContext, snap_id: String) -> Result<Rating,
             AppError::Unknown
         })?;
 
-    let rating = Rating::new(snap_id, votes);
+    let rating = Rating::new(votes);
 
     Ok(rating)
 }

--- a/src/features/chart/entities.rs
+++ b/src/features/chart/entities.rs
@@ -1,7 +1,8 @@
+use crate::features::{
+    common::entities::{calculate_band, Rating, VoteSummary},
+    pb::chart as pb,
+};
 use sqlx::FromRow;
-
-use crate::features::common::entities::{calculate_band, Rating, VoteSummary};
-use crate::features::pb::chart as pb;
 
 pub struct Chart {
     pub timeframe: pb::Timeframe,

--- a/src/features/chart/entities.rs
+++ b/src/features/chart/entities.rs
@@ -19,9 +19,12 @@ impl Chart {
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
 
+        // Take only the first 20 elements from the sorted chart_data
+        let top_20: Vec<ChartData> = chart_data.into_iter().take(20).collect();
+
         Chart {
             timeframe,
-            chart_data,
+            chart_data: top_20,
         }
     }
 }

--- a/src/features/chart/entities.rs
+++ b/src/features/chart/entities.rs
@@ -1,0 +1,53 @@
+use sqlx::FromRow;
+
+use crate::features::common::entities::{calculate_band, Rating, VoteSummary};
+use crate::features::pb::chart as pb;
+
+pub struct Chart {
+    pub timeframe: pb::Timeframe,
+    pub chart_data: Vec<ChartData>,
+}
+
+impl Chart {
+    pub fn new(timeframe: pb::Timeframe, data: Vec<VoteSummary>) -> Self {
+        let mut chart_data: Vec<ChartData> =
+            data.into_iter().map(ChartData::from_vote_summary).collect();
+
+        chart_data.sort_by(|a, b| {
+            b.raw_rating
+                .partial_cmp(&a.raw_rating)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        Chart {
+            timeframe,
+            chart_data,
+        }
+    }
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct ChartData {
+    pub raw_rating: f32,
+    pub rating: Rating,
+}
+
+impl ChartData {
+    pub fn from_vote_summary(vote_summary: VoteSummary) -> Self {
+        let (raw_rating, ratings_band) = calculate_band(&vote_summary);
+        let rating = Rating {
+            snap_id: vote_summary.snap_id,
+            total_votes: vote_summary.total_votes as u64,
+            ratings_band,
+        };
+        let raw_rating = raw_rating.unwrap_or(0.0) as f32;
+        Self { raw_rating, rating }
+    }
+
+    pub fn into_dto(self) -> pb::ChartData {
+        pb::ChartData {
+            raw_rating: self.raw_rating,
+            rating: Some(self.rating.into_dto()),
+        }
+    }
+}

--- a/src/features/chart/errors.rs
+++ b/src/features/chart/errors.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ChartError {
+    #[error("failed to get chart for timeframe")]
+    FailedToGetChart,
+    #[error("unknown chart error")]
+    Unknown,
+}

--- a/src/features/chart/errors.rs
+++ b/src/features/chart/errors.rs
@@ -6,4 +6,6 @@ pub enum ChartError {
     FailedToGetChart,
     #[error("unknown chart error")]
     Unknown,
+    #[error("could not find data for given timeframe")]
+    NotFound,
 }

--- a/src/features/chart/infrastructure.rs
+++ b/src/features/chart/infrastructure.rs
@@ -44,7 +44,7 @@ pub(crate) async fn get_votes_summary_by_timeframe(
         .await
         .map_err(|error| {
             error!("{error:?}");
-            ChartError::Unknown
+            ChartError::NotFound
         })?;
 
     Ok(result)

--- a/src/features/chart/infrastructure.rs
+++ b/src/features/chart/infrastructure.rs
@@ -1,9 +1,8 @@
-use crate::app::AppContext;
-use crate::features::common::entities::VoteSummary;
-use crate::features::pb::chart::Timeframe;
+use crate::{
+    app::AppContext,
+    features::{chart::errors::ChartError, common::entities::VoteSummary, pb::chart::Timeframe},
+};
 use tracing::error;
-
-use super::errors::ChartError;
 
 pub(crate) async fn get_votes_summary_by_timeframe(
     app_ctx: &AppContext,

--- a/src/features/chart/infrastructure.rs
+++ b/src/features/chart/infrastructure.rs
@@ -1,0 +1,51 @@
+use crate::app::AppContext;
+use crate::features::common::entities::VoteSummary;
+use crate::features::pb::chart::Timeframe;
+use tracing::error;
+
+use super::errors::ChartError;
+
+pub(crate) async fn get_votes_summary_by_timeframe(
+    app_ctx: &AppContext,
+    timeframe: Timeframe,
+) -> Result<Vec<VoteSummary>, ChartError> {
+    let mut pool = app_ctx
+        .infrastructure()
+        .repository()
+        .await
+        .map_err(|error| {
+            error!("{error:?}");
+            ChartError::FailedToGetChart
+        })?;
+
+    // Generate WHERE clause based on timeframe
+    let where_clause = match timeframe {
+        Timeframe::Week => "WHERE votes.created >= NOW() - INTERVAL '1 week'",
+        Timeframe::Month => "WHERE votes.created >= NOW() - INTERVAL '1 month'",
+        Timeframe::Unspecified => "", // Adjust as needed for Unspecified case
+    };
+
+    let query = format!(
+        r#"
+            SELECT
+                votes.snap_id,
+                COUNT(*) AS total_votes,
+                COUNT(*) FILTER (WHERE votes.vote_up) AS positive_votes
+            FROM
+                votes
+            {}
+            GROUP BY votes.snap_id
+        "#,
+        where_clause
+    );
+
+    let result = sqlx::query_as::<_, VoteSummary>(&query)
+        .fetch_all(&mut *pool)
+        .await
+        .map_err(|error| {
+            error!("{error:?}");
+            ChartError::Unknown
+        })?;
+
+    Ok(result)
+}

--- a/src/features/chart/interface.rs
+++ b/src/features/chart/interface.rs
@@ -5,6 +5,7 @@ use tonic::{Request, Response, Status};
 
 use crate::features::pb::chart::chart_server::Chart;
 
+use super::errors::ChartError;
 use super::{service::ChartService, use_cases};
 
 #[tonic::async_trait]
@@ -41,7 +42,12 @@ impl Chart for ChartService {
                 };
                 Ok(Response::new(payload))
             }
-            Err(_error) => Err(Status::unknown("Internal server error")),
+            Err(error) => match error {
+                ChartError::NotFound => {
+                    Err(Status::not_found("Cannot find data for given timeframe."))
+                }
+                _ => Err(Status::unknown("Internal server error")),
+            },
         }
     }
 }

--- a/src/features/chart/interface.rs
+++ b/src/features/chart/interface.rs
@@ -29,15 +29,18 @@ impl Chart for ChartService {
 
         match result {
             Ok(result) => {
-
-                let ordered_chart_data = result.chart_data.into_iter().map(|chart_data| chart_data.into_dto()).collect();
+                let ordered_chart_data = result
+                    .chart_data
+                    .into_iter()
+                    .map(|chart_data| chart_data.into_dto())
+                    .collect();
 
                 let payload = GetChartResponse {
                     timeframe: timeframe.into(),
                     ordered_chart_data,
                 };
                 Ok(Response::new(payload))
-            },
+            }
             Err(_error) => Err(Status::unknown("Internal server error")),
         }
     }

--- a/src/features/chart/interface.rs
+++ b/src/features/chart/interface.rs
@@ -1,12 +1,11 @@
-use crate::app::AppContext;
-
-use crate::features::pb::chart::{GetChartRequest, GetChartResponse, Timeframe};
+use crate::{
+    app::AppContext,
+    features::{
+        chart::{errors::ChartError, service::ChartService, use_cases},
+        pb::chart::{chart_server::Chart, GetChartRequest, GetChartResponse, Timeframe},
+    },
+};
 use tonic::{Request, Response, Status};
-
-use crate::features::pb::chart::chart_server::Chart;
-
-use super::errors::ChartError;
-use super::{service::ChartService, use_cases};
 
 #[tonic::async_trait]
 impl Chart for ChartService {

--- a/src/features/chart/interface.rs
+++ b/src/features/chart/interface.rs
@@ -1,0 +1,44 @@
+use crate::app::AppContext;
+
+use crate::features::pb::chart::{GetChartRequest, GetChartResponse, Timeframe};
+use tonic::{Request, Response, Status};
+
+use crate::features::pb::chart::chart_server::Chart;
+
+use super::{service::ChartService, use_cases};
+
+#[tonic::async_trait]
+impl Chart for ChartService {
+    #[tracing::instrument]
+    async fn get_chart(
+        &self,
+        request: Request<GetChartRequest>,
+    ) -> Result<Response<GetChartResponse>, Status> {
+        let app_ctx = request.extensions().get::<AppContext>().unwrap().clone();
+
+        let GetChartRequest { timeframe } = request.into_inner();
+
+        let timeframe = match timeframe {
+            0 => Timeframe::Unspecified,
+            1 => Timeframe::Week,
+            2 => Timeframe::Month,
+            _ => Timeframe::Unspecified,
+        };
+
+        let result = use_cases::get_chart(&app_ctx, timeframe).await;
+
+        match result {
+            Ok(result) => {
+
+                let ordered_chart_data = result.chart_data.into_iter().map(|chart_data| chart_data.into_dto()).collect();
+
+                let payload = GetChartResponse {
+                    timeframe: timeframe.into(),
+                    ordered_chart_data,
+                };
+                Ok(Response::new(payload))
+            },
+            Err(_error) => Err(Status::unknown("Internal server error")),
+        }
+    }
+}

--- a/src/features/chart/mod.rs
+++ b/src/features/chart/mod.rs
@@ -1,0 +1,6 @@
+pub mod entities;
+mod errors;
+mod infrastructure;
+pub mod interface;
+pub mod service;
+mod use_cases;

--- a/src/features/chart/service.rs
+++ b/src/features/chart/service.rs
@@ -1,0 +1,9 @@
+use crate::features::pb::chart::chart_server::ChartServer;
+
+#[derive(Debug, Default)]
+pub struct ChartService;
+
+pub fn build_service() -> ChartServer<ChartService> {
+    let service = ChartService;
+    ChartServer::new(service)
+}

--- a/src/features/chart/use_cases.rs
+++ b/src/features/chart/use_cases.rs
@@ -1,9 +1,13 @@
-use super::{errors::ChartError, infrastructure::get_votes_summary_by_timeframe};
-use crate::app::AppContext;
-use crate::features::chart::entities::Chart;
-use crate::features::pb::chart::Timeframe;
+use crate::{
+    app::AppContext,
+    features::{
+        chart::{
+            entities::Chart, errors::ChartError, infrastructure::get_votes_summary_by_timeframe,
+        },
+        pb::chart::Timeframe,
+    },
+};
 use tracing::error;
-// use super::{entities::Rating, errors::AppError, infrastructure::get_votes_by_snap_id};
 
 pub async fn get_chart(app_ctx: &AppContext, timeframe: Timeframe) -> Result<Chart, ChartError> {
     let votes = get_votes_summary_by_timeframe(app_ctx, timeframe)

--- a/src/features/chart/use_cases.rs
+++ b/src/features/chart/use_cases.rs
@@ -1,0 +1,19 @@
+use super::{errors::ChartError, infrastructure::get_votes_summary_by_timeframe};
+use crate::app::AppContext;
+use crate::features::chart::entities::Chart;
+use crate::features::pb::chart::Timeframe;
+use tracing::error;
+// use super::{entities::Rating, errors::AppError, infrastructure::get_votes_by_snap_id};
+
+pub async fn get_chart(app_ctx: &AppContext, timeframe: Timeframe) -> Result<Chart, ChartError> {
+    let votes = get_votes_summary_by_timeframe(app_ctx, timeframe)
+        .await
+        .map_err(|error| {
+            error!("{error:?}");
+            ChartError::Unknown
+        })?;
+
+    let chart = Chart::new(timeframe, votes);
+
+    Ok(chart)
+}

--- a/src/features/common/entities.rs
+++ b/src/features/common/entities.rs
@@ -1,8 +1,6 @@
 use sqlx::FromRow;
 
-pub mod protobuf {
-    tonic::include_proto!("ratings.features.common");
-}
+use crate::features::pb::common as pb;
 
 const INSUFFICIENT_VOTES_QUANTITY: usize = 25;
 
@@ -55,8 +53,8 @@ impl Rating {
         }
     }
 
-    pub(crate) fn into_dto(self) -> protobuf::Rating {
-        protobuf::Rating {
+    pub(crate) fn into_dto(self) -> pb::Rating {
+        pb::Rating {
             snap_id: self.snap_id,
             total_votes: self.total_votes,
             ratings_band: self.ratings_band as i32,

--- a/src/features/common/entities.rs
+++ b/src/features/common/entities.rs
@@ -1,6 +1,8 @@
 use sqlx::FromRow;
 
-use super::interface::protobuf;
+pub mod protobuf {
+    tonic::include_proto!("ratings.features.common");
+}
 
 const INSUFFICIENT_VOTES_QUANTITY: usize = 25;
 

--- a/src/features/common/entities.rs
+++ b/src/features/common/entities.rs
@@ -2,7 +2,7 @@ use sqlx::FromRow;
 
 use crate::features::pb::common as pb;
 
-const INSUFFICIENT_VOTES_QUANTITY: usize = 25;
+const INSUFFICIENT_VOTES_QUANTITY: i64 = 25;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RatingsBand {
@@ -43,12 +43,11 @@ pub struct Rating {
 }
 
 impl Rating {
-    pub fn new(snap_id: String, votes: Vec<Vote>) -> Self {
-        let total_votes = votes.len();
-        let ratings_band = calculate_band(votes);
+    pub fn new(votes: VoteSummary) -> Self {
+        let (_, ratings_band) = calculate_band(&votes);
         Self {
-            snap_id,
-            total_votes: total_votes as u64,
+            snap_id: votes.snap_id,
+            total_votes: votes.total_votes as u64,
             ratings_band,
         }
     }
@@ -62,27 +61,31 @@ impl Rating {
     }
 }
 
+#[derive(Debug, Clone, FromRow)]
+pub struct VoteSummary {
+    pub snap_id: String,
+    pub total_votes: i64,
+    pub positive_votes: i64,
+}
+
 #[derive(Debug, Clone)]
 pub struct Vote {
     pub vote_up: bool,
 }
 
-fn calculate_band(votes: Vec<Vote>) -> RatingsBand {
-    let total_ratings = votes.len();
-    if total_ratings < INSUFFICIENT_VOTES_QUANTITY {
-        return RatingsBand::InsufficientVotes;
+pub fn calculate_band(votes: &VoteSummary) -> (Option<f64>, RatingsBand) {
+    if votes.total_votes < INSUFFICIENT_VOTES_QUANTITY {
+        return (None, RatingsBand::InsufficientVotes);
     }
-    let positive_ratings = votes
-        .into_iter()
-        .filter(|vote| vote.vote_up)
-        .collect::<Vec<Vote>>()
-        .len();
-    let adjusted_ratio = confidence_interval_lower_bound(positive_ratings, total_ratings);
+    let adjusted_ratio = confidence_interval_lower_bound(votes.positive_votes, votes.total_votes);
 
-    RatingsBand::from_value(adjusted_ratio)
+    (
+        Some(adjusted_ratio),
+        RatingsBand::from_value(adjusted_ratio),
+    )
 }
 
-fn confidence_interval_lower_bound(positive_ratings: usize, total_ratings: usize) -> f64 {
+fn confidence_interval_lower_bound(positive_ratings: i64, total_ratings: i64) -> f64 {
     if total_ratings == 0 {
         return 0.0;
     }
@@ -136,7 +139,7 @@ mod tests {
         let mut last_lower_bound = 0.0;
 
         for total_ratings in (100..1000).step_by(100) {
-            let positive_ratings = (total_ratings as f64 * ratio).round() as usize;
+            let positive_ratings = (total_ratings as f64 * ratio).round() as i64;
             let new_lower_bound = confidence_interval_lower_bound(positive_ratings, total_ratings);
             let raw_positive_ratio = positive_ratings as f64 / total_ratings as f64;
 
@@ -152,23 +155,39 @@ mod tests {
 
     #[test]
     fn test_insufficient_votes() {
-        let votes = vec![Vote { vote_up: true }];
-        let band = calculate_band(votes);
+        let votes = VoteSummary {
+            snap_id: 1.to_string(),
+            total_votes: 1,
+            positive_votes: 1,
+        };
+        let (rating, band) = calculate_band(&votes);
         assert_eq!(
             band,
             RatingsBand::InsufficientVotes,
             "Should return InsufficientVotes when not enough votes exist for a given Snap."
+        );
+        assert!(
+            rating.is_none(),
+            "Should return band = None for insufficient votes."
         )
     }
 
     #[test]
     fn test_sufficient_votes() {
-        let votes = vec![Vote { vote_up: true }; INSUFFICIENT_VOTES_QUANTITY];
-        let band = calculate_band(votes);
+        let votes = VoteSummary {
+            snap_id: 1.to_string(),
+            total_votes: 100,
+            positive_votes: 100,
+        };
+        let (rating, band) = calculate_band(&votes);
         assert_eq!(
             band,
             RatingsBand::VeryGood,
             "Should return very good for a sufficient number of all positive votes."
+        );
+        assert!(
+            rating > Some(0.7),
+            "Should return fairly positive raw rating for this ration and volume of positive votes."
         )
     }
 }

--- a/src/features/common/mod.rs
+++ b/src/features/common/mod.rs
@@ -1,0 +1,1 @@
+pub mod entities;

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -1,2 +1,3 @@
 pub mod app;
+mod common;
 pub mod user;

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -1,3 +1,4 @@
 pub mod app;
 mod common;
+mod pb;
 pub mod user;

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod chart;
 mod common;
 mod pb;
 pub mod user;

--- a/src/features/pb.rs
+++ b/src/features/pb.rs
@@ -1,0 +1,11 @@
+pub mod app {
+    include!("../../proto/ratings.features.app.rs");
+}
+
+pub mod common {
+    include!("../../proto/ratings.features.common.rs");
+}
+
+pub mod user {
+    include!("../../proto/ratings.features.user.rs");
+}

--- a/src/features/pb.rs
+++ b/src/features/pb.rs
@@ -9,3 +9,7 @@ pub mod common {
 pub mod user {
     include!("../../proto/ratings.features.user.rs");
 }
+
+pub mod chart {
+    include!("../../proto/ratings.features.chart.rs");
+}

--- a/src/features/user/entities.rs
+++ b/src/features/user/entities.rs
@@ -1,7 +1,7 @@
 use sqlx::FromRow;
 use time::OffsetDateTime;
 
-use super::interface::protobuf;
+use crate::features::pb::user;
 
 pub type ClientHash = String;
 
@@ -35,13 +35,13 @@ pub struct Vote {
 }
 
 impl Vote {
-    pub(crate) fn into_dto(self) -> protobuf::Vote {
+    pub(crate) fn into_dto(self) -> user::Vote {
         let timestamp = Some(prost_types::Timestamp {
             seconds: self.timestamp.unix_timestamp(),
             nanos: 0,
         });
 
-        protobuf::Vote {
+        user::Vote {
             snap_id: self.snap_id,
             snap_revision: self.snap_revision as i32,
             vote_up: self.vote_up,

--- a/src/features/user/interface.rs
+++ b/src/features/user/interface.rs
@@ -2,8 +2,6 @@ use time::OffsetDateTime;
 
 use tonic::{Request, Response, Status};
 
-pub use protobuf::user_server;
-
 use crate::app::AppContext;
 use crate::utils::jwt::Claims;
 
@@ -11,16 +9,12 @@ use super::entities::Vote;
 use super::service::UserService;
 use super::use_cases;
 
-use self::protobuf::{
+use crate::features::pb::user::{
     AuthenticateRequest, AuthenticateResponse, GetSnapVotesRequest, GetSnapVotesResponse,
-    ListMyVotesRequest, ListMyVotesResponse, User, VoteRequest,
+    ListMyVotesRequest, ListMyVotesResponse, VoteRequest,
 };
 
-pub mod protobuf {
-    pub use self::user_server::User;
-
-    tonic::include_proto!("ratings.features.user");
-}
+use crate::features::pb::user::user_server::User;
 
 #[tonic::async_trait]
 impl User for UserService {

--- a/src/features/user/interface.rs
+++ b/src/features/user/interface.rs
@@ -1,20 +1,17 @@
 use time::OffsetDateTime;
-
 use tonic::{Request, Response, Status};
 
-use crate::app::AppContext;
-use crate::utils::jwt::Claims;
-
-use super::entities::Vote;
-use super::service::UserService;
-use super::use_cases;
-
-use crate::features::pb::user::{
-    AuthenticateRequest, AuthenticateResponse, GetSnapVotesRequest, GetSnapVotesResponse,
-    ListMyVotesRequest, ListMyVotesResponse, VoteRequest,
+use crate::{
+    app::AppContext,
+    features::{
+        pb::user::{
+            user_server::User, AuthenticateRequest, AuthenticateResponse, GetSnapVotesRequest,
+            GetSnapVotesResponse, ListMyVotesRequest, ListMyVotesResponse, VoteRequest,
+        },
+        user::{entities::Vote, service::UserService, use_cases},
+    },
+    utils::jwt::Claims,
 };
-
-use crate::features::pb::user::user_server::User;
 
 #[tonic::async_trait]
 impl User for UserService {

--- a/src/features/user/service.rs
+++ b/src/features/user/service.rs
@@ -1,4 +1,4 @@
-use super::interface::user_server::UserServer;
+use crate::features::pb::user::user_server::UserServer;
 
 #[derive(Debug, Default)]
 pub struct UserService;

--- a/src/features/user/use_cases.rs
+++ b/src/features/user/use_cases.rs
@@ -1,10 +1,13 @@
-use crate::app::AppContext;
-use crate::features::user::infrastructure::{find_user_votes, save_vote_to_db};
-
-use super::entities::{User, Vote};
-use super::errors::UserError;
-use super::infrastructure::{
-    create_or_seen_user, delete_user_by_client_hash, get_snap_votes_by_client_hash,
+use crate::{
+    app::AppContext,
+    features::user::{
+        entities::{User, Vote},
+        errors::UserError,
+        infrastructure::{
+            create_or_seen_user, delete_user_by_client_hash, find_user_votes,
+            get_snap_votes_by_client_hash, save_vote_to_db,
+        },
+    },
 };
 
 pub async fn authenticate(app_ctx: &AppContext, id: &str) -> Result<User, UserError> {

--- a/tests/app_tests/lifecycle_test.rs
+++ b/tests/app_tests/lifecycle_test.rs
@@ -7,11 +7,10 @@ use ratings::{
 use super::super::helpers::with_lifecycle::with_lifecycle;
 use crate::helpers::test_data::TestData;
 use crate::helpers::vote_generator::generate_votes;
-use crate::helpers::{self, client_app::pb::RatingsBand, client_app::AppClient};
-use crate::helpers::{
-    client_user::{pb::AuthenticateResponse, UserClient},
-    data_faker,
-};
+use crate::helpers::{self, client_app::AppClient};
+use crate::helpers::{client_user::UserClient, data_faker};
+use crate::pb::common::RatingsBand;
+use crate::pb::user::AuthenticateResponse;
 
 #[tokio::test]
 async fn app_lifecycle_test() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/app_tests/lifecycle_test.rs
+++ b/tests/app_tests/lifecycle_test.rs
@@ -25,6 +25,7 @@ async fn app_lifecycle_test() -> Result<(), Box<dyn std::error::Error>> {
         token: None,
         app_client: Some(AppClient::new(&config.socket())),
         snap_id: Some(data_faker::rnd_id()),
+        chart_client: None,
     };
 
     with_lifecycle(async {

--- a/tests/chart_tests/lifecycle_test.rs
+++ b/tests/chart_tests/lifecycle_test.rs
@@ -1,0 +1,234 @@
+use futures::FutureExt;
+use ratings::{
+    app::AppContext,
+    utils::{Config, Infrastructure},
+};
+
+use super::super::helpers::with_lifecycle::with_lifecycle;
+use crate::{helpers::{test_data::TestData, client_chart::ChartClient}, pb::{chart::Timeframe, common::Rating}};
+use crate::helpers::vote_generator::generate_votes;
+use crate::helpers::{self, client_app::AppClient};
+use crate::helpers::{client_user::UserClient, data_faker};
+use crate::pb::common::RatingsBand;
+use crate::pb::user::AuthenticateResponse;
+
+#[tokio::test]
+async fn chart_lifecycle_test() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::load()?;
+    let infra = Infrastructure::new(&config).await?;
+    let app_ctx = AppContext::new(&config, infra);
+
+    let data = TestData {
+        user_client: Some(UserClient::new(&config.socket())),
+        app_ctx,
+        id: None,
+        token: None,
+        app_client: Some(AppClient::new(&config.socket())),
+        snap_id: Some(data_faker::rnd_id()),
+        chart_client: Some(ChartClient::new(&config.socket())),
+    };
+
+    with_lifecycle(async {
+        vote_once(data.clone()).then(multiple_votes).then(timeframed_votes_dont_appear).await;
+    })
+    .await;
+    Ok(())
+}
+
+// Does an app voted against once appear correctly in the chart?
+async fn vote_once(mut data: TestData) -> TestData {
+    let vote_up = true;
+    let expected_raw_rating = 0.0;
+    let expected_rating = Rating {
+        snap_id: data.snap_id.clone().unwrap(),
+        total_votes: 1,
+        ratings_band: RatingsBand::InsufficientVotes.into(),
+    };
+
+    generate_votes(
+        &data.snap_id.clone().unwrap(),
+        111,
+        vote_up,
+        1,
+        data.clone(),
+    )
+    .await
+    .expect("Votes should succeed");
+
+    let id: String = helpers::data_faker::rnd_sha_256();
+    data.id = Some(id.to_string());
+
+    let client = data.user_client.clone().unwrap();
+    let response: AuthenticateResponse = client.authenticate(&id).await.unwrap().into_inner();
+    let token: String = response.token;
+    data.token = Some(token.to_string());
+
+    let timeframe = Timeframe::Unspecified;
+
+let chart_data_result = data
+    .clone()
+    .chart_client
+    .unwrap()
+    .get_chart(timeframe, &data.token.clone().unwrap())
+    .await
+    .expect("Get Chart should succeed")
+    .into_inner()
+    .ordered_chart_data;
+
+let result = chart_data_result.into_iter()
+    .find(|chart_data| {
+        if let Some(rating) = &chart_data.rating {
+            rating.snap_id == data.snap_id.clone().unwrap()
+        } else {
+            false
+        }
+    });
+
+    let actual_rating = result.clone().unwrap().rating.unwrap();
+    let actual_raw_rating = result.unwrap().raw_rating;
+
+    assert_eq!(expected_rating, actual_rating);
+    assert_eq!(expected_raw_rating, actual_raw_rating);
+
+    data
+}
+
+// Does an app voted against multiple times appear correctly in the chart?
+async fn multiple_votes(mut data: TestData) -> TestData {
+    let vote_up = true;
+    let expected_raw_rating = 0.8;
+    let expected_rating = Rating {
+        snap_id: data.snap_id.clone().unwrap(),
+        total_votes: 25,
+        ratings_band: RatingsBand::VeryGood.into(),
+    };
+
+    generate_votes(
+        &data.snap_id.clone().unwrap(),
+        111,
+        vote_up,
+        24,
+        data.clone(),
+    )
+    .await
+    .expect("Votes should succeed");
+
+    let id: String = helpers::data_faker::rnd_sha_256();
+    data.id = Some(id.to_string());
+
+    let client = data.user_client.clone().unwrap();
+    let response: AuthenticateResponse = client.authenticate(&id).await.unwrap().into_inner();
+    let token: String = response.token;
+    data.token = Some(token.to_string());
+
+    let timeframe = Timeframe::Unspecified;
+
+let chart_data_result = data
+    .clone()
+    .chart_client
+    .unwrap()
+    .get_chart(timeframe, &data.token.clone().unwrap())
+    .await
+    .expect("Get Chart should succeed")
+    .into_inner()
+    .ordered_chart_data;
+
+let result = chart_data_result.into_iter()
+    .find(|chart_data| {
+        if let Some(rating) = &chart_data.rating {
+            rating.snap_id == data.snap_id.clone().unwrap()
+        } else {
+            false
+        }
+    });
+
+    let actual_rating = result.clone().unwrap().rating.unwrap();
+    let actual_raw_rating = result.unwrap().raw_rating;
+
+    assert_eq!(expected_rating, actual_rating);
+    assert!(expected_raw_rating < actual_raw_rating);
+
+    data
+}
+
+// Does the Timeframe correctly filter out app data?
+async fn timeframed_votes_dont_appear(mut data: TestData) -> TestData {
+    let mut conn = data.repository().await.unwrap();
+
+    // Timewarp the votes back two months so they are out of the requested timeframe
+    sqlx::query("UPDATE votes SET created = created - INTERVAL '2 months' WHERE snap_id = $1")
+        .bind(&data.snap_id.clone().unwrap())
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+
+    let id: String = helpers::data_faker::rnd_sha_256();
+    data.id = Some(id.to_string());
+
+    let client = data.user_client.clone().unwrap();
+    let response: AuthenticateResponse = client.authenticate(&id).await.unwrap().into_inner();
+    let token: String = response.token;
+    data.token = Some(token.to_string());
+
+    let timeframe = Timeframe::Month;
+
+let chart_data_result = data
+    .clone()
+    .chart_client
+    .unwrap()
+    .get_chart(timeframe, &data.token.clone().unwrap())
+    .await
+    .expect("Get Chart should succeed")
+    .into_inner()
+    .ordered_chart_data;
+
+    let result = chart_data_result.into_iter()
+    .find(|chart_data| {
+        if let Some(rating) = &chart_data.rating {
+            rating.snap_id == data.snap_id.clone().unwrap()
+        } else {
+            false
+        }
+    });
+
+    // Should no longer find the ratings as they are too old
+    assert_eq!(result, None);
+
+    let expected_raw_rating = 0.8;
+    let expected_rating = Rating {
+        snap_id: data.snap_id.clone().unwrap(),
+        total_votes: 25,
+        ratings_band: RatingsBand::VeryGood.into(),
+    };
+
+    // Unspecified timeframe should now pick up the ratings again
+    let timeframe = Timeframe::Unspecified;
+    let chart_data_result = data
+        .clone()
+        .chart_client
+        .unwrap()
+        .get_chart(timeframe, &data.token.clone().unwrap())
+        .await
+        .expect("Get Chart should succeed")
+        .into_inner()
+        .ordered_chart_data;
+
+
+let result = chart_data_result.into_iter()
+    .find(|chart_data| {
+        if let Some(rating) = &chart_data.rating {
+            rating.snap_id == data.snap_id.clone().unwrap()
+        } else {
+            false
+        }
+    });
+
+    let actual_rating = result.clone().unwrap().rating.unwrap();
+    let actual_raw_rating = result.unwrap().raw_rating;
+
+    assert_eq!(expected_rating, actual_rating);
+    assert!(expected_raw_rating < actual_raw_rating);
+
+
+    data
+}

--- a/tests/chart_tests/lifecycle_test.rs
+++ b/tests/chart_tests/lifecycle_test.rs
@@ -5,12 +5,15 @@ use ratings::{
 };
 
 use super::super::helpers::with_lifecycle::with_lifecycle;
-use crate::{helpers::{test_data::TestData, client_chart::ChartClient}, pb::{chart::Timeframe, common::Rating}};
 use crate::helpers::vote_generator::generate_votes;
 use crate::helpers::{self, client_app::AppClient};
 use crate::helpers::{client_user::UserClient, data_faker};
 use crate::pb::common::RatingsBand;
 use crate::pb::user::AuthenticateResponse;
+use crate::{
+    helpers::{client_chart::ChartClient, test_data::TestData},
+    pb::{chart::Timeframe, common::Rating},
+};
 
 #[tokio::test]
 async fn chart_lifecycle_test() -> Result<(), Box<dyn std::error::Error>> {
@@ -29,7 +32,10 @@ async fn chart_lifecycle_test() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     with_lifecycle(async {
-        vote_once(data.clone()).then(multiple_votes).then(timeframed_votes_dont_appear).await;
+        vote_once(data.clone())
+            .then(multiple_votes)
+            .then(timeframed_votes_dont_appear)
+            .await;
     })
     .await;
     Ok(())
@@ -65,18 +71,17 @@ async fn vote_once(mut data: TestData) -> TestData {
 
     let timeframe = Timeframe::Unspecified;
 
-let chart_data_result = data
-    .clone()
-    .chart_client
-    .unwrap()
-    .get_chart(timeframe, &data.token.clone().unwrap())
-    .await
-    .expect("Get Chart should succeed")
-    .into_inner()
-    .ordered_chart_data;
+    let chart_data_result = data
+        .clone()
+        .chart_client
+        .unwrap()
+        .get_chart(timeframe, &data.token.clone().unwrap())
+        .await
+        .expect("Get Chart should succeed")
+        .into_inner()
+        .ordered_chart_data;
 
-let result = chart_data_result.into_iter()
-    .find(|chart_data| {
+    let result = chart_data_result.into_iter().find(|chart_data| {
         if let Some(rating) = &chart_data.rating {
             rating.snap_id == data.snap_id.clone().unwrap()
         } else {
@@ -123,18 +128,17 @@ async fn multiple_votes(mut data: TestData) -> TestData {
 
     let timeframe = Timeframe::Unspecified;
 
-let chart_data_result = data
-    .clone()
-    .chart_client
-    .unwrap()
-    .get_chart(timeframe, &data.token.clone().unwrap())
-    .await
-    .expect("Get Chart should succeed")
-    .into_inner()
-    .ordered_chart_data;
+    let chart_data_result = data
+        .clone()
+        .chart_client
+        .unwrap()
+        .get_chart(timeframe, &data.token.clone().unwrap())
+        .await
+        .expect("Get Chart should succeed")
+        .into_inner()
+        .ordered_chart_data;
 
-let result = chart_data_result.into_iter()
-    .find(|chart_data| {
+    let result = chart_data_result.into_iter().find(|chart_data| {
         if let Some(rating) = &chart_data.rating {
             rating.snap_id == data.snap_id.clone().unwrap()
         } else {
@@ -172,18 +176,17 @@ async fn timeframed_votes_dont_appear(mut data: TestData) -> TestData {
 
     let timeframe = Timeframe::Month;
 
-let chart_data_result = data
-    .clone()
-    .chart_client
-    .unwrap()
-    .get_chart(timeframe, &data.token.clone().unwrap())
-    .await
-    .expect("Get Chart should succeed")
-    .into_inner()
-    .ordered_chart_data;
+    let chart_data_result = data
+        .clone()
+        .chart_client
+        .unwrap()
+        .get_chart(timeframe, &data.token.clone().unwrap())
+        .await
+        .expect("Get Chart should succeed")
+        .into_inner()
+        .ordered_chart_data;
 
-    let result = chart_data_result.into_iter()
-    .find(|chart_data| {
+    let result = chart_data_result.into_iter().find(|chart_data| {
         if let Some(rating) = &chart_data.rating {
             rating.snap_id == data.snap_id.clone().unwrap()
         } else {
@@ -213,9 +216,7 @@ let chart_data_result = data
         .into_inner()
         .ordered_chart_data;
 
-
-let result = chart_data_result.into_iter()
-    .find(|chart_data| {
+    let result = chart_data_result.into_iter().find(|chart_data| {
         if let Some(rating) = &chart_data.rating {
             rating.snap_id == data.snap_id.clone().unwrap()
         } else {
@@ -228,7 +229,6 @@ let result = chart_data_result.into_iter()
 
     assert_eq!(expected_rating, actual_rating);
     assert!(expected_raw_rating < actual_raw_rating);
-
 
     data
 }

--- a/tests/helpers/client_app.rs
+++ b/tests/helpers/client_app.rs
@@ -1,10 +1,7 @@
 use tonic::{metadata::MetadataValue, transport::Endpoint, Request, Response, Status};
 
-pub mod pb {
-    pub use self::app_client::AppClient;
-
-    tonic::include_proto!("ratings.features.app");
-}
+use crate::pb::app::app_client as pb;
+use crate::pb::app::{GetRatingRequest, GetRatingResponse};
 
 #[derive(Debug, Clone)]
 pub struct AppClient {
@@ -22,7 +19,7 @@ impl AppClient {
         &self,
         id: &str,
         token: &str,
-    ) -> Result<Response<pb::GetRatingResponse>, Status> {
+    ) -> Result<Response<GetRatingResponse>, Status> {
         let channel = Endpoint::from_shared(self.url.clone())
             .unwrap()
             .connect()
@@ -34,7 +31,7 @@ impl AppClient {
             Ok(req)
         });
         client
-            .get_rating(pb::GetRatingRequest {
+            .get_rating(GetRatingRequest {
                 snap_id: id.to_string(),
             })
             .await

--- a/tests/helpers/client_chart.rs
+++ b/tests/helpers/client_chart.rs
@@ -3,9 +3,7 @@ use tonic::transport::Endpoint;
 use tonic::{Request, Response, Status};
 
 use crate::pb::chart::{chart_client as pb, Timeframe};
-use crate::pb::chart::{
-    GetChartRequest, GetChartResponse
-};
+use crate::pb::chart::{GetChartRequest, GetChartResponse};
 
 #[derive(Debug, Clone)]
 pub struct ChartClient {
@@ -35,7 +33,7 @@ impl ChartClient {
             Ok(req)
         });
         client
-            .get_chart(GetChartRequest{
+            .get_chart(GetChartRequest {
                 timeframe: timeframe.into(),
             })
             .await

--- a/tests/helpers/client_chart.rs
+++ b/tests/helpers/client_chart.rs
@@ -1,39 +1,42 @@
-use tonic::{metadata::MetadataValue, transport::Endpoint, Request, Response, Status};
+use tonic::metadata::MetadataValue;
+use tonic::transport::Endpoint;
+use tonic::{Request, Response, Status};
 
-use crate::pb::app::{GetRatingRequest, GetRatingResponse};
-
-use crate::pb::app::app_client as pb;
+use crate::pb::chart::{chart_client as pb, Timeframe};
+use crate::pb::chart::{
+    GetChartRequest, GetChartResponse
+};
 
 #[derive(Debug, Clone)]
-pub struct AppClient {
+pub struct ChartClient {
     url: String,
 }
 
-impl AppClient {
+impl ChartClient {
     pub fn new(socket: &str) -> Self {
         Self {
             url: format!("http://{socket}/"),
         }
     }
 
-    pub async fn get_rating(
+    pub async fn get_chart(
         &self,
-        id: &str,
+        timeframe: Timeframe,
         token: &str,
-    ) -> Result<Response<GetRatingResponse>, Status> {
+    ) -> Result<Response<GetChartResponse>, Status> {
         let channel = Endpoint::from_shared(self.url.clone())
             .unwrap()
             .connect()
             .await
             .unwrap();
-        let mut client = pb::AppClient::with_interceptor(channel, move |mut req: Request<()>| {
+        let mut client = pb::ChartClient::with_interceptor(channel, move |mut req: Request<()>| {
             let header: MetadataValue<_> = format!("Bearer {token}").parse().unwrap();
             req.metadata_mut().insert("authorization", header);
             Ok(req)
         });
         client
-            .get_rating(GetRatingRequest {
-                snap_id: id.to_string(),
+            .get_chart(GetChartRequest{
+                timeframe: timeframe.into(),
             })
             .await
     }

--- a/tests/helpers/client_user.rs
+++ b/tests/helpers/client_user.rs
@@ -2,12 +2,11 @@ use tonic::metadata::MetadataValue;
 use tonic::transport::Endpoint;
 use tonic::{Request, Response, Status};
 
-use self::pb::GetSnapVotesResponse;
-pub mod pb {
-    pub use self::user_client::UserClient;
-
-    tonic::include_proto!("ratings.features.user");
-}
+use crate::pb::user::user_client as pb;
+use crate::pb::user::{
+    AuthenticateRequest, AuthenticateResponse, GetSnapVotesRequest, GetSnapVotesResponse,
+    VoteRequest,
+};
 
 #[derive(Debug, Clone)]
 pub struct UserClient {
@@ -22,18 +21,15 @@ impl UserClient {
     }
 
     #[allow(dead_code)]
-    pub async fn authenticate(
-        &self,
-        id: &str,
-    ) -> Result<Response<pb::AuthenticateResponse>, Status> {
+    pub async fn authenticate(&self, id: &str) -> Result<Response<AuthenticateResponse>, Status> {
         let mut client = pb::UserClient::connect(self.url.clone()).await.unwrap();
         client
-            .authenticate(pb::AuthenticateRequest { id: id.to_string() })
+            .authenticate(AuthenticateRequest { id: id.to_string() })
             .await
     }
 
     #[allow(dead_code)]
-    pub async fn vote(&self, token: &str, ballet: pb::VoteRequest) -> Result<Response<()>, Status> {
+    pub async fn vote(&self, token: &str, ballet: VoteRequest) -> Result<Response<()>, Status> {
         let channel = Endpoint::from_shared(self.url.clone())
             .unwrap()
             .connect()
@@ -51,7 +47,7 @@ impl UserClient {
     pub async fn get_snap_votes(
         &self,
         token: &str,
-        request: pb::GetSnapVotesRequest,
+        request: GetSnapVotesRequest,
     ) -> Result<Response<GetSnapVotesResponse>, Status> {
         let channel = Endpoint::from_shared(self.url.clone())
             .unwrap()

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,5 +1,6 @@
 pub mod assert;
 pub mod client_app;
+pub mod client_chart;
 pub mod client_user;
 pub mod data_faker;
 pub mod hooks;

--- a/tests/helpers/test_data.rs
+++ b/tests/helpers/test_data.rs
@@ -3,11 +3,13 @@ use sqlx::{pool::PoolConnection, Postgres};
 
 use super::client_app::AppClient;
 use super::client_user::UserClient;
+use super::client_chart::ChartClient;
 
 #[derive(Debug, Clone)]
 pub struct TestData {
     pub user_client: Option<UserClient>,
     pub app_client: Option<AppClient>,
+    pub chart_client: Option<ChartClient>,
     pub id: Option<String>,
     pub snap_id: Option<String>,
     pub token: Option<String>,

--- a/tests/helpers/test_data.rs
+++ b/tests/helpers/test_data.rs
@@ -2,8 +2,8 @@ use ratings::app::AppContext;
 use sqlx::{pool::PoolConnection, Postgres};
 
 use super::client_app::AppClient;
-use super::client_user::UserClient;
 use super::client_chart::ChartClient;
+use super::client_user::UserClient;
 
 #[derive(Debug, Clone)]
 pub struct TestData {

--- a/tests/helpers/vote_generator.rs
+++ b/tests/helpers/vote_generator.rs
@@ -1,6 +1,6 @@
-use super::super::helpers::client_user::pb::{AuthenticateResponse, VoteRequest};
 use super::test_data::TestData;
 use crate::helpers;
+use crate::pb::user::{AuthenticateResponse, VoteRequest};
 
 pub async fn generate_votes(
     snap_id: &str,

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -9,6 +9,10 @@ mod app_tests {
     mod lifecycle_test;
 }
 
+mod chart_tests {
+    mod lifecycle_test;
+}
+
 mod helpers;
 
 mod pb;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -10,3 +10,5 @@ mod app_tests {
 }
 
 mod helpers;
+
+mod pb;

--- a/tests/pb.rs
+++ b/tests/pb.rs
@@ -9,3 +9,7 @@ pub mod common {
 pub mod user {
     include!("../proto/ratings.features.user.rs");
 }
+
+pub mod chart {
+    include!("../proto/ratings.features.chart.rs");
+}

--- a/tests/pb.rs
+++ b/tests/pb.rs
@@ -1,0 +1,11 @@
+pub mod app {
+    include!("../proto/ratings.features.app.rs");
+}
+
+pub mod common {
+    include!("../proto/ratings.features.common.rs");
+}
+
+pub mod user {
+    include!("../proto/ratings.features.user.rs");
+}

--- a/tests/user_tests/double_authenticate_test.rs
+++ b/tests/user_tests/double_authenticate_test.rs
@@ -22,6 +22,7 @@ async fn authenticate_twice_test() -> Result<(), Box<dyn std::error::Error>> {
         token: None,
         app_client: None,
         snap_id: None,
+        chart_client: None,
     };
 
     with_lifecycle(async {

--- a/tests/user_tests/double_authenticate_test.rs
+++ b/tests/user_tests/double_authenticate_test.rs
@@ -1,9 +1,9 @@
 use crate::helpers;
 use crate::helpers::test_data::TestData;
 
-use super::super::helpers::client_user::pb::AuthenticateResponse;
 use super::super::helpers::client_user::UserClient;
 use super::super::helpers::with_lifecycle::with_lifecycle;
+use crate::pb::user::AuthenticateResponse;
 use ratings::app::AppContext;
 use ratings::utils::{self, Infrastructure};
 use sqlx::Row;

--- a/tests/user_tests/get_votes_lifecycle_test.rs
+++ b/tests/user_tests/get_votes_lifecycle_test.rs
@@ -25,6 +25,7 @@ async fn get_votes_lifecycle_test() -> Result<(), Box<dyn std::error::Error>> {
         token: None,
         app_client: None,
         snap_id: None,
+        chart_client: None,
     };
 
     with_lifecycle(async {

--- a/tests/user_tests/get_votes_lifecycle_test.rs
+++ b/tests/user_tests/get_votes_lifecycle_test.rs
@@ -1,8 +1,8 @@
 use crate::helpers;
-use crate::helpers::client_user::pb::GetSnapVotesRequest;
 use crate::helpers::test_data::TestData;
 
-use super::super::helpers::client_user::pb::{AuthenticateResponse, VoteRequest};
+use crate::pb::user::{AuthenticateResponse, GetSnapVotesRequest, VoteRequest};
+
 use super::super::helpers::client_user::UserClient;
 use super::super::helpers::with_lifecycle::with_lifecycle;
 use futures::FutureExt;

--- a/tests/user_tests/simple_lifecycle_test.rs
+++ b/tests/user_tests/simple_lifecycle_test.rs
@@ -1,10 +1,10 @@
 use crate::helpers;
+use futures::FutureExt;
 use crate::helpers::test_data::TestData;
 
 use super::super::helpers::client_user::UserClient;
 use super::super::helpers::with_lifecycle::with_lifecycle;
 use crate::pb::user::{AuthenticateResponse, VoteRequest};
-use futures::FutureExt;
 use ratings::app::AppContext;
 use ratings::utils::{self, Infrastructure};
 use sqlx::Row;
@@ -24,6 +24,7 @@ async fn user_simple_lifecycle_test() -> Result<(), Box<dyn std::error::Error>> 
         token: None,
         app_client: None,
         snap_id: None,
+        chart_client: None,
     };
 
     with_lifecycle(async {

--- a/tests/user_tests/simple_lifecycle_test.rs
+++ b/tests/user_tests/simple_lifecycle_test.rs
@@ -1,9 +1,9 @@
 use crate::helpers;
 use crate::helpers::test_data::TestData;
 
-use super::super::helpers::client_user::pb::{AuthenticateResponse, VoteRequest};
 use super::super::helpers::client_user::UserClient;
 use super::super::helpers::with_lifecycle::with_lifecycle;
+use crate::pb::user::{AuthenticateResponse, VoteRequest};
 use futures::FutureExt;
 use ratings::app::AppContext;
 use ratings::utils::{self, Infrastructure};

--- a/tests/user_tests/simple_lifecycle_test.rs
+++ b/tests/user_tests/simple_lifecycle_test.rs
@@ -1,6 +1,6 @@
 use crate::helpers;
-use futures::FutureExt;
 use crate::helpers::test_data::TestData;
+use futures::FutureExt;
 
 use super::super::helpers::client_user::UserClient;
 use super::super::helpers::with_lifecycle::with_lifecycle;


### PR DESCRIPTION
- Updated `ChartData` to include the ratings_band and raw rating
- Removed chart types
- Refactoring protos to make Ratings common and reusable across `features/app` & `features/chart`
- Refactoring entities to make `Rating` and `RatingsBand` reusable
- Refactoring db methods to use `VoteSummary` instead of extracting a list of votes and processing in Rust
- Implementing `getChart` endpoint
- e2e tests now run in ci

Closes #35, #15 

[Client update](https://github.com/canonical/app_center_ratings_client.dart/pull/9)