### PR TITLE
Move Github Actions to `apt` version of protoc

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -20,10 +20,7 @@ jobs:
       - name: Install additional build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libssl-dev pkg-config
-
-          sudo snap install protobuf --classic
-
+          sudo apt-get install -y libssl-dev pkg-config protobuf-compiler
       - name: Check code format
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
The snap hasn't been updated since 2021 and
doesn't allow since stabilized features like
`optional`.

Required for #70
