### PR TITLE
Improve Cargo.lock git handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Cargo.lock merge=ours


### PR DESCRIPTION
This makes it much more ergonomic to work with
a checked in `Cargo.lock` by automatically
preferring the new version when merge conflicts
arise (i.e. any time you change a dependency)
