### PR TITLE
Add conventional commits lint

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,14 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: webiny/action-conventional-commits@v1.3.0


### PR DESCRIPTION
As the title says, this would need to be activated in the repo settings, however.