### PR TITLE
feat: dockerfile includes mounting sql migrations

### DIFF
--- a/docker/ratings/Dockerfile
+++ b/docker/ratings/Dockerfile
@@ -4,6 +4,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y && rm -r
 
 WORKDIR /app
 COPY target/release/ratings /app/ratings
+COPY sql/migrations /app/sql/migrations
 
 EXPOSE 8080
 ENTRYPOINT ["/app/ratings"]


### PR DESCRIPTION
I ran into trouble with the rock OCI image, as Zoe's library relies on a local snapd that is not present in a stripped down rock: https://github.com/ZoopOTheGoop/snapd-rs/blob/framework/src/connection/mod.rs#L39

For now I am reverting to the Docker image Tim wrote, but ratings can't start without first running the migrator, so this updates the Dockerfile to copy that dir over into the image.

