### PR TITLE
test: adding tests to cover chart order returned

### DIFF
--- a/tests/chart.rs
+++ b/tests/chart.rs
@@ -6,6 +6,7 @@ pub mod common;
 
 use common::{Category, TestHelper};
 use rand::{thread_rng, Rng};
+use simple_test_case::test_case;
 
 // !! This test expects to be the only one making use of the "Development" category
 #[tokio::test]
@@ -33,6 +34,40 @@ async fn category_chart_returns_expected_top_snap() -> anyhow::Result<()> {
 
     let top_snap = data[0].rating.take().expect("to have rating for top snap");
     assert_eq!(top_snap.snap_id, snap_id, "{top_snap:?}");
+
+    Ok(())
+}
+
+#[test_case(&[(0, 25), (10, 15), (25, 0)], &[2,1,0], Category::DevicesAndIot; "Creation order is reverse rating order")]
+#[test_case(&[(27, 0), (25, 0), (26, 0)], &[0,2,1], Category::NewsAndWeather; "More positive votes is weighted higher")]
+#[tokio::test]
+async fn category_chart_returns_expected_order(
+    snap_votes: &[(u64, u64)],
+    expected_order: &[usize],
+    category: Category,
+) -> anyhow::Result<()> {
+    let t = TestHelper::new();
+    let mut ids = Vec::with_capacity(snap_votes.len());
+
+    for &(upvotes, downvotes) in snap_votes.iter() {
+        let id = t
+            .test_snap_with_initial_votes(1, upvotes, downvotes, &[category])
+            .await?;
+        ids.push(id);
+    }
+
+    let user_token = t.authenticate(t.random_sha_256()).await?;
+    let data = t.get_chart(Some(category), &user_token).await?;
+
+    let chart_indicies: Vec<usize> = data
+        .into_iter()
+        .map(|c| {
+            ids.iter()
+                .position(|id| id == &c.rating.as_ref().unwrap().snap_id)
+                .unwrap()
+        })
+        .collect();
+    assert_eq!(&chart_indicies, expected_order);
 
     Ok(())
 }


### PR DESCRIPTION
Adding tests for the ordering of charts returned from the `get_charts` endpoint.