### PR TITLE
feat: stub out the new application layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,10 +401,8 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -2259,16 +2257,20 @@ dependencies = [
 name = "ratings_new"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "dotenvy",
  "envy",
- "git2",
+ "jsonwebtoken",
  "prost 0.13.3",
  "prost-types 0.13.3",
+ "reqwest",
+ "secrecy",
  "serde",
+ "serde_json",
  "simple_test_case",
  "sqlx",
+ "strum",
  "thiserror",
+ "time",
  "tokio",
  "tonic 0.12.2",
  "tonic-build",
@@ -2817,7 +2819,6 @@ dependencies = [
  "atoi",
  "byteorder",
  "bytes",
- "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -2902,7 +2903,6 @@ dependencies = [
  "bitflags 2.6.0",
  "byteorder",
  "bytes",
- "chrono",
  "crc",
  "digest",
  "dotenvy",
@@ -2945,7 +2945,6 @@ dependencies = [
  "base64 0.22.1",
  "bitflags 2.6.0",
  "byteorder",
- "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -2982,7 +2981,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5b2cf34a45953bfd3daaf3db0f7a7878ab9b7a6b91b422d24a7a9e4c857b680"
 dependencies = [
  "atoi",
- "chrono",
  "flume",
  "futures-channel",
  "futures-core",

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ down:
 test:
 	@cargo test --lib
 
+.PHONY: db-test
+db-test:
+	@cargo test --lib --features db_tests
+
 .PHONY: integration-test
 integration-test: clear-db-data
 	@APP_JWT_SECRET='deadbeef' \
@@ -27,7 +31,7 @@ integration-test: clear-db-data
 		cargo test --test '*' $(ARGS)
 
 .PHONY: test-all
-test-all: test integration-test
+test-all: db-test integration-test
 
 .PHONY: wait-for-server
 wait-for-server:

--- a/crates/ratings_new/Cargo.toml
+++ b/crates/ratings_new/Cargo.toml
@@ -4,14 +4,19 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.38"
-dotenvy = "0.15.7"
-envy = "0.4.2"
+dotenvy = "0.15"
+envy = "0.4"
+jsonwebtoken = "9.2"
 prost = "0.13.3"
 prost-types = "0.13.3"
-serde = { version = "1.0.210", features = ["derive"] }
-sqlx = { version = "0.8.2", features = ["runtime-tokio-rustls", "postgres", "chrono", "migrate", "time"] }
+reqwest = "0.12"
+secrecy = { version = "0.8.0", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.114"
+sqlx = { version = "0.8.2", features = ["runtime-tokio-rustls", "postgres", "migrate", "time"] }
+strum = { version = "0.26.2", features = ["derive"] }
 thiserror = "1.0.64"
+time = "0.3"
 tokio = { version = "1.40.0", features = ["full"] }
 tonic = "0.12.2"
 tonic-reflection = "0.12.2"
@@ -22,5 +27,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 simple_test_case = "1.2.0"
 
 [build-dependencies]
-git2 = { version = "0.18.2", default-features = false }
 tonic-build = { version = "0.11", features = ["prost"] }

--- a/crates/ratings_new/Cargo.toml
+++ b/crates/ratings_new/Cargo.toml
@@ -3,6 +3,14 @@ name = "ratings_new"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# Used to prevent tests that need a running DB from executing unless explicitly requested
+# Annotate such tests with the following:
+#   #[cfg_attr(not(feature = "db_tests"), ignore)]
+#
+# Execute the tests using "cargo test --features db_tests"
+db_tests = []
+
 [dependencies]
 dotenvy = "0.15"
 envy = "0.4"

--- a/crates/ratings_new/build.rs
+++ b/crates/ratings_new/build.rs
@@ -1,4 +1,3 @@
-use git2::Repository;
 use std::path::Path;
 
 fn init_proto() -> Result<(), Box<dyn std::error::Error>> {
@@ -33,25 +32,8 @@ fn init_proto() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn include_build_info() -> Result<(), Box<dyn std::error::Error>> {
-    let repo = Repository::open(std::env::current_dir()?.parent().unwrap().parent().unwrap())?;
-    let head = repo.head()?;
-    let branch = head
-        .name()
-        .unwrap()
-        .strip_prefix("refs/heads/")
-        .unwrap_or("no-branch");
-    println!("cargo:rustc-env=GIT_BRANCH={}", branch);
-
-    let commit_sha = repo.head()?.target().unwrap();
-    println!("cargo:rustc-env=GIT_HASH={}", commit_sha);
-
-    Ok(())
-}
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_proto()?;
-    include_build_info()?;
 
     Ok(())
 }

--- a/crates/ratings_new/src/config.rs
+++ b/crates/ratings_new/src/config.rs
@@ -1,6 +1,6 @@
 //! Utility functions and definitions for configuring the service.
 use dotenvy::dotenv;
-// use secrecy::SecretString;
+use secrecy::SecretString;
 use serde::Deserialize;
 use tokio::sync::OnceCell;
 
@@ -14,7 +14,7 @@ pub struct Config {
     /// The host configuration
     pub host: String,
     /// The JWT secret value
-    // pub jwt_secret: SecretString,
+    pub jwt_secret: SecretString,
     /// Log level to use
     pub log_level: String,
     /// The service name
@@ -23,22 +23,26 @@ pub struct Config {
     pub port: u16,
     /// The URI of the postgres database
     pub postgres_uri: String,
+    /// The base URI for snapcraft.io
+    pub snapcraft_io_uri: String,
 }
 
 impl Config {
     /// Loads the configuration from environment variables
     pub fn load() -> envy::Result<Config> {
         dotenv().ok();
+
         envy::prefixed("APP_").from_env::<Config>()
     }
 
-    pub async fn get() -> Result<&'static Config, envy::Error> {
+    pub async fn get() -> envy::Result<&'static Config> {
         CONFIG.get_or_try_init(|| async { Config::load() }).await
     }
 
     /// Return a [`String`] representing the socket to run the service on
     pub fn socket(&self) -> String {
         let Config { port, host, .. } = self;
+
         format!("{host}:{port}")
     }
 }

--- a/crates/ratings_new/src/context.rs
+++ b/crates/ratings_new/src/context.rs
@@ -1,0 +1,82 @@
+//! Application level context & state
+use crate::config::Config;
+use jsonwebtoken::{EncodingKey, Header};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, sync::Arc};
+use time::{Duration, OffsetDateTime};
+use tokio::sync::{Mutex, Notify};
+use tracing::error;
+
+/// How many days until JWT info expires
+static JWT_EXPIRY_DAYS: i64 = 1;
+
+/// Errors that can happen while encoding and signing tokens with JWT.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("jwt: error decoding secret: {0}")]
+    DecodeSecretError(#[from] jsonwebtoken::errors::Error),
+
+    #[error("jwt: an error occurred, but the reason was erased for security reasons")]
+    Erased,
+}
+
+pub struct Context {
+    pub jwt_encoder: Arc<JwtEncoder>,
+    pub http_client: Arc<reqwest::Client>,
+    /// In progress category updates that we need to block on
+    pub category_updates: Arc<Mutex<HashMap<String, Arc<Notify>>>>,
+}
+
+impl Context {
+    pub fn new(config: &Config) -> Result<Self, Error> {
+        Ok(Self {
+            jwt_encoder: Arc::new(JwtEncoder::from_secret(&config.jwt_secret)?),
+            http_client: Arc::new(reqwest::Client::new()),
+            category_updates: Default::default(),
+        })
+    }
+}
+
+/// Information representating a claim on a specific subject at a specific time
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Claims {
+    /// The subject
+    pub sub: String,
+    /// The expiration time
+    pub exp: usize,
+}
+
+impl Claims {
+    /// Creates a new claim with the current datetime for the subject given by `sub`.
+    pub fn new(sub: String) -> Self {
+        let exp = OffsetDateTime::now_utc() + Duration::days(JWT_EXPIRY_DAYS);
+        let exp = exp.unix_timestamp() as usize;
+
+        Self { sub, exp }
+    }
+}
+
+pub struct JwtEncoder {
+    encoding_key: EncodingKey,
+}
+
+impl JwtEncoder {
+    pub fn from_secret(secret: &SecretString) -> Result<JwtEncoder, Error> {
+        let encoding_key = EncodingKey::from_base64_secret(secret.expose_secret())?;
+
+        Ok(Self { encoding_key })
+    }
+
+    pub fn encode(&self, sub: String) -> Result<String, Error> {
+        let claims = Claims::new(sub);
+
+        match jsonwebtoken::encode(&Header::default(), &claims, &self.encoding_key) {
+            Ok(s) => Ok(s),
+            Err(e) => {
+                error!("unable to encode jwt: {e}");
+                Err(Error::Erased)
+            }
+        }
+    }
+}

--- a/crates/ratings_new/src/db/categories.rs
+++ b/crates/ratings_new/src/db/categories.rs
@@ -1,7 +1,7 @@
-use super::Result;
+use crate::db::Result;
 use sqlx::{PgConnection, Postgres, QueryBuilder};
 
-#[derive(sqlx::Type)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type, strum::EnumString, strum::Display)]
 #[repr(i32)]
 pub enum Category {
     ArtAndDesign = 0,
@@ -49,5 +49,6 @@ pub async fn set_categories_for_snap(
     });
 
     query_builder.build().execute(conn).await?;
+
     Ok(())
 }

--- a/crates/ratings_new/src/db/migrator.rs
+++ b/crates/ratings_new/src/db/migrator.rs
@@ -23,6 +23,7 @@ impl Migrator {
     pub async fn new(uri: &str) -> Result<Migrator, sqlx::Error> {
         let pool = PgPoolOptions::new().max_connections(1).connect(uri).await?;
         let pool = Arc::new(pool);
+
         Ok(Migrator { pool })
     }
 
@@ -43,6 +44,7 @@ impl Migrator {
             sqlx::migrate::Migrator::new(std::path::Path::new(&Self::migrations_path())).await?;
 
         m.run(&mut self.pool.acquire().await?).await?;
+
         Ok(())
     }
 

--- a/crates/ratings_new/src/db/mod.rs
+++ b/crates/ratings_new/src/db/mod.rs
@@ -83,6 +83,7 @@ mod tests {
     use sqlx::types::time::OffsetDateTime;
     use tracing_subscriber::EnvFilter;
 
+    #[cfg_attr(not(feature = "db_tests"), ignore)]
     #[tokio::test]
     async fn save_and_read_votes() -> Result<()> {
         let client_hash_1 = "0000000000000000000000000000000000000000000000000000000000000001";
@@ -159,6 +160,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg_attr(not(feature = "db_tests"), ignore)]
     #[tokio::test]
     async fn update_categories() -> Result<()> {
         let conn = conn!();

--- a/crates/ratings_new/src/db/user.rs
+++ b/crates/ratings_new/src/db/user.rs
@@ -1,4 +1,4 @@
-use super::{ClientHash, DbError, Result};
+use crate::db::{ClientHash, Error, Result};
 use sqlx::{prelude::FromRow, types::time::OffsetDateTime, PgConnection};
 use tracing::error;
 
@@ -43,7 +43,7 @@ impl User {
         .await
         .map_err(|error| {
             error!("{error:?}");
-            DbError::FailedToCreateUserRecord
+            Error::FailedToCreateUserRecord
         })?;
 
         Ok(user_with_id)
@@ -61,8 +61,9 @@ impl User {
         .await
         .map_err(|error| {
             error!("{error:?}");
-            DbError::FailedToDeleteUserRecord
+            Error::FailedToDeleteUserRecord
         })?;
+
         Ok(())
     }
 }

--- a/crates/ratings_new/src/db/vote.rs
+++ b/crates/ratings_new/src/db/vote.rs
@@ -1,4 +1,4 @@
-use super::{ClientHash, DbError, Result};
+use super::{ClientHash, Error, Result};
 use sqlx::{types::time::OffsetDateTime, FromRow, PgConnection};
 use tracing::error;
 
@@ -55,7 +55,7 @@ impl Vote {
         .await
         .map_err(|error| {
             error!("{error:?}");
-            DbError::FailedToGetUserVote
+            Error::FailedToGetUserVote
         })?;
 
         Ok(votes)
@@ -79,7 +79,7 @@ impl Vote {
         .await
         .map_err(|error| {
             error!("{error:?}");
-            DbError::FailedToCastVote
+            Error::FailedToCastVote
         })?;
 
         Ok(result.rows_affected())

--- a/crates/ratings_new/src/lib.rs
+++ b/crates/ratings_new/src/lib.rs
@@ -1,5 +1,10 @@
+pub mod config;
+pub mod context;
 pub mod db;
 pub mod grpc;
 pub mod middleware;
 pub mod proto;
-pub mod utils;
+pub mod ratings;
+
+pub use config::Config;
+pub use context::Context;

--- a/crates/ratings_new/src/ratings/categories.rs
+++ b/crates/ratings_new/src/ratings/categories.rs
@@ -1,0 +1,200 @@
+//! Updating snap categories from data in snapcraft.io
+use crate::{
+    db::categories::{set_categories_for_snap, snap_has_categories, Category},
+    Config, Context,
+};
+use serde::{de::DeserializeOwned, Deserialize};
+use sqlx::PgConnection;
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::sync::Notify;
+use tracing::error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Db(#[from] crate::db::Error),
+
+    #[error(transparent)]
+    Envy(#[from] envy::Error),
+
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+
+    #[error(transparent)]
+    Strum(#[from] strum::ParseError),
+
+    #[error("invalid url: {0}")]
+    InvalidUrl(String),
+
+    #[error(transparent)]
+    SnapcraftIo(#[from] reqwest::Error),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+
+/// Update the categories for a given snap.
+///
+/// In the case where we do not have categories, we need to fetch them and store them in the DB.
+/// This is racey without coordination so we check to see if any other tasks are currently attempting
+/// this and block on them completing if they are, if not then we set up the Notify and they block on us.
+pub async fn update_categories(
+    snap_id: &str,
+    ctx: &Context,
+    conn: &mut PgConnection,
+) -> Result<(), Error> {
+    // If we have categories for the requested snap in place already then skip updating.
+    // Eventually we will need to update and refresh categories over time but the assumption for now is
+    // that snap categories do not change frequently so we do not need to eagerly update them.
+    if snap_has_categories(snap_id, conn).await? {
+        return Ok(());
+    }
+
+    let mut guard = ctx.category_updates.lock().await;
+    let (notifier, should_wait) = match guard.get(&snap_id.to_string()) {
+        Some(notifier) => (notifier.clone(), true),
+        None => (Arc::new(Notify::new()), false),
+    };
+
+    if should_wait {
+        // Another task is updating the categories for this snap so wait for it to complete and then
+        // return: https://docs.rs/tokio/latest/tokio/sync/struct.Notify.html#method.notified
+        drop(guard);
+        notifier.notified().await;
+        return Ok(());
+    }
+
+    // At this point we can release the mutex for other calls to update_categories to proceed while
+    // we update the DB state for the snap_id we are interested in. Any calls between now and when
+    // we complete the update will block on the notifier we insert here.
+    guard.insert(snap_id.to_string(), notifier.clone());
+    drop(guard);
+
+    // We can't early return while holding the Notifier as that will leave any waiting tasks
+    // blocked. Rather than attempt to retry at this stage we allow for stale category data
+    // until a new task attempts to get data for the same snap.
+    let base = &Config::get().await?.snapcraft_io_uri;
+    if let Err(e) = update_categories_inner(snap_id, base, &ctx.http_client, conn).await {
+        error!(%snap_id, "unable to update snap categories: {e}");
+    }
+
+    // Grab the mutex around the category_updates so any incoming tasks block behind us and then
+    // notify all blocked tasks before removing the Notify from the map.
+    let mut guard = ctx.category_updates.lock().await;
+    notifier.notify_waiters();
+    guard.remove(&snap_id.to_string());
+
+    Ok(())
+}
+
+#[inline]
+async fn update_categories_inner(
+    snap_id: &str,
+    base: &str,
+    client: &reqwest::Client,
+    conn: &mut PgConnection,
+) -> Result<(), Error> {
+    let categories = get_snap_categories(snap_id, base, client).await?;
+    set_categories_for_snap(snap_id, categories, conn).await?;
+
+    Ok(())
+}
+
+#[inline]
+async fn get_json<T: DeserializeOwned>(
+    url: reqwest::Url,
+    query: &[(&str, &str)],
+    client: &reqwest::Client,
+) -> Result<T, Error> {
+    let s = client
+        .get(url)
+        .header("User-Agent", "ratings-service")
+        .header("Snap-Device-Series", 16)
+        .query(query)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    Ok(serde_json::from_str(&s)?)
+}
+
+/// Pull snap categories by for a given snapd_id from the snapcraft.io rest API
+async fn get_snap_categories(
+    snap_id: &str,
+    base: &str,
+    client: &reqwest::Client,
+) -> Result<Vec<Category>, Error> {
+    let base_url = reqwest::Url::parse(base).map_err(|e| Error::InvalidUrl(e.to_string()))?;
+
+    let assertions_url = base_url
+        .join(&format!("assertions/snap-declaration/16/{snap_id}"))
+        .map_err(|e| Error::InvalidUrl(e.to_string()))?;
+
+    let AssertionsResp {
+        headers: Headers { snap_name },
+    } = get_json(assertions_url, &[], client).await?;
+
+    let info_url = base_url
+        .join(&format!("snaps/info/{snap_name}"))
+        .map_err(|e| Error::InvalidUrl(e.to_string()))?;
+
+    let FindResp {
+        snap: SnapInfo { categories },
+    } = get_json(info_url, &[("fields", "categories")], client).await?;
+
+    let res: Result<Vec<Category>, Error> = categories
+        .into_iter()
+        .map(|c| Category::try_from(c.name.as_str()).map_err(Into::into))
+        .collect();
+
+    return res;
+
+    // serde structs
+
+    #[derive(Debug, Deserialize)]
+    struct AssertionsResp {
+        headers: Headers,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "kebab-case")]
+    struct Headers {
+        snap_name: String,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct FindResp {
+        snap: SnapInfo,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct SnapInfo {
+        categories: Vec<RawCategory>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct RawCategory {
+        name: String,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Can be run explicitly to validate the behaviour of the API calls we make against
+    // snapcraft.io but we don't want to do this in local testing or CI by default.
+    #[ignore = "hits snapcraft.io"]
+    #[tokio::test]
+    async fn get_snap_categories_works() {
+        let client = reqwest::Client::new();
+        let base = "https://api.snapcraft.io/v2/";
+        let snap_id = "NeoQngJVBf2wKC48bxnF2xqmfEFGdVnx"; // steam
+        let categories = get_snap_categories(snap_id, base, &client).await.unwrap();
+
+        assert_eq!(categories, vec![Category::Games]);
+    }
+}

--- a/crates/ratings_new/src/ratings/mod.rs
+++ b/crates/ratings_new/src/ratings/mod.rs
@@ -1,0 +1,2 @@
+//! Business logic building on top of the db layer
+pub mod categories;

--- a/crates/ratings_new/src/utils/mod.rs
+++ b/crates/ratings_new/src/utils/mod.rs
@@ -1,5 +1,0 @@
-pub use config::Config;
-pub use migrator::Migrator;
-
-pub mod config;
-pub mod migrator;


### PR DESCRIPTION
There is still a fair amount of work to do before the application layer is finished but this should be sufficient for @matthew-hagemann to complete work on the GRPC services by stubbing out any required interfaces in the new `ratings` module. Once that work is merged I'll pick things back up and port over the remaining business logic from the current server and then wire everything in :+1: 