### PR TITLE
feat: add caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
+name = "cached"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9718806c4a2fe9e8a56fd736f97b340dd10ed1be8ed733ed50449f351dc33cae"
+dependencies = [
+ "ahash",
+ "async-trait",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "futures",
+ "hashbrown 0.14.5",
+ "once_cell",
+ "thiserror",
+ "tokio",
+ "web-time",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
+
+[[package]]
 name = "cc"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +349,41 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -955,6 +1026,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1638,6 +1715,7 @@ name = "ratings"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cached",
  "dotenvy",
  "envy",
  "futures",
@@ -2315,6 +2393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2937,6 +3021,16 @@ name = "web-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 db_tests = []
 
 [dependencies]
+cached = { version = "0.54.0", features = ["async"] }
 dotenvy = "0.15"
 envy = "0.4"
 http = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2021"
 # Execute the tests using "cargo test --features db_tests"
 db_tests = []
 
+# Used to skip caching of rating data in integration tests
+skip_cache = []
+
 [dependencies]
 cached = { version = "0.54.0", features = ["async"] }
 dotenvy = "0.15"

--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,10 @@ fn init_proto() -> Result<(), Box<dyn std::error::Error>> {
         )
         .compile(files, &["proto"])?;
 
+    if std::env::var("SKIP_CACHE").is_ok() {
+        println!("cargo:rustc-cfg=feature=\"skip_cache\"");
+    }
+
     Ok(())
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       #APP_SNAPCRAFT_IO_URI: "https://api.snapcraft.io/v2/"
       APP_ADMIN_USER: "shadow"
       APP_ADMIN_PASSWORD: "maria"
+      SKIP_CACHE: "true"
     volumes:
       - .:/app
       - cargo-cache:/usr/local/cargo/registry

--- a/src/db/categories.rs
+++ b/src/db/categories.rs
@@ -7,6 +7,7 @@ use sqlx::{PgConnection, Postgres, QueryBuilder};
     Copy,
     PartialEq,
     Eq,
+    Hash,
     sqlx::Type,
     strum::EnumString,
     strum::Display,

--- a/src/db/vote.rs
+++ b/src/db/vote.rs
@@ -1,4 +1,5 @@
 use crate::db::{categories::Category, ClientHash, Error, Result};
+use cached::proc_macro::cached;
 use sqlx::{types::time::OffsetDateTime, FromRow, PgConnection, QueryBuilder};
 use tracing::error;
 
@@ -107,30 +108,7 @@ pub struct VoteSummary {
 
 impl VoteSummary {
     pub async fn get_by_snap_id(snap_id: &str, conn: &mut PgConnection) -> Result<VoteSummary> {
-        let result: Option<VoteSummary> = sqlx::query_as(
-            r#"
-            SELECT
-                votes.snap_id,
-                COUNT(*) AS total_votes,
-                COUNT(*) FILTER (WHERE votes.vote_up) AS positive_votes
-            FROM
-                votes
-            WHERE
-                votes.snap_id = $1
-            GROUP BY votes.snap_id
-        "#,
-        )
-        .bind(snap_id)
-        .fetch_optional(conn)
-        .await?;
-
-        let summary = result.unwrap_or_else(|| VoteSummary {
-            snap_id: snap_id.to_string(),
-            total_votes: 0,
-            positive_votes: 0,
-        });
-
-        Ok(summary)
+        get_by_snap_id_cached(snap_id, conn).await
     }
 
     /// Retrieves the vote summary over a given [Timeframe], optionally for a specific [Category]
@@ -172,4 +150,38 @@ impl VoteSummary {
 
         Ok(summaries)
     }
+}
+
+#[cached(
+    time = 86400, // 24 hours
+    sync_writes = true,
+    key = "String",
+    convert = r##"{String::from(snap_id)}"##,
+    result = true,
+)]
+async fn get_by_snap_id_cached(snap_id: &str, conn: &mut PgConnection) -> Result<VoteSummary> {
+    let result: Option<VoteSummary> = sqlx::query_as(
+        r#"
+            SELECT
+                votes.snap_id,
+                COUNT(*) AS total_votes,
+                COUNT(*) FILTER (WHERE votes.vote_up) AS positive_votes
+            FROM
+                votes
+            WHERE
+                votes.snap_id = $1
+            GROUP BY votes.snap_id
+        "#,
+    )
+    .bind(snap_id)
+    .fetch_optional(conn)
+    .await?;
+
+    let summary = result.unwrap_or_else(|| VoteSummary {
+        snap_id: snap_id.to_string(),
+        total_votes: 0,
+        positive_votes: 0,
+    });
+
+    Ok(summary)
 }

--- a/src/db/vote.rs
+++ b/src/db/vote.rs
@@ -86,7 +86,7 @@ impl Vote {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::FromRepr)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::FromRepr)]
 #[repr(i32)]
 pub enum Timeframe {
     Unspecified,

--- a/src/db/vote.rs
+++ b/src/db/vote.rs
@@ -152,13 +152,13 @@ impl VoteSummary {
     }
 }
 
-#[cached(
+#[cfg_attr(not(feature = "skip_cache"), cached(
     time = 86400, // 24 hours
     sync_writes = true,
     key = "String",
     convert = r##"{String::from(snap_id)}"##,
     result = true,
-)]
+))]
 async fn get_by_snap_id_cached(snap_id: &str, conn: &mut PgConnection) -> Result<VoteSummary> {
     let result: Option<VoteSummary> = sqlx::query_as(
         r#"

--- a/src/grpc/charts.rs
+++ b/src/grpc/charts.rs
@@ -77,12 +77,12 @@ impl chart_server::Chart for ChartService {
     }
 }
 
-#[cached(
+#[cfg_attr(not(feature = "skip_cache"), cached(
     time = 86400, // 24 hours
     sync_writes = true,
     result = true,
     with_cached_flag = true
-)]
+))]
 async fn get_chart_cached(
     category: Option<Category>,
     timeframe: Timeframe,

--- a/src/ratings/categories.rs
+++ b/src/ratings/categories.rs
@@ -141,10 +141,13 @@ async fn get_snap_categories(
     }
 }
 
-#[cached(
-    key = "String",
-    convert = r##"{String::from(snap_id)}"##,
-    result = true
+#[cfg_attr(
+    not(feature = "skip_cache"),
+    cached(
+        key = "String",
+        convert = r##"{String::from(snap_id)}"##,
+        result = true
+    )
 )]
 async fn get_snap_name(
     snap_id: &str,

--- a/src/ratings/charts.rs
+++ b/src/ratings/charts.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use std::cmp::Ordering;
 
+#[derive(Debug, Clone)]
 pub struct Chart {
     pub timeframe: Timeframe,
     pub data: Vec<ChartData>,


### PR DESCRIPTION
Adds some simple caching logic to prevent too many unnecessary db requests, constant re-calculation of the top charts and spamming snapcraft.io with requests to resolve snap IDs.

- [x] charts (`get_chart`, cached for 24 hours)
- [x] `snap_name`s (`get_snap_name`, cached indefinitely, currently used in the category updates, will also be used for the charts when migrating from IDs to names)
- [x] individual votes (`get_by_snap_id`, cached for 24 hours)

Personal vote data (`get_all_by_client_hash`) is not cached.

Caching can be disabled at compile time (for integration tests) via the `SKIP_CACHE` environment variable.

UDENG-5543