### PR TITLE
feat!: remove obsolete `ListMyVotes` method

### DIFF
--- a/proto/ratings_features_user.proto
+++ b/proto/ratings_features_user.proto
@@ -10,7 +10,6 @@ service User {
 
   rpc Delete (google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc Vote (VoteRequest) returns (google.protobuf.Empty) {}
-  rpc ListMyVotes (ListMyVotesRequest) returns (ListMyVotesResponse) {}
   rpc GetSnapVotes(GetSnapVotesRequest) returns (GetSnapVotesResponse) {}
 }
 
@@ -21,14 +20,6 @@ message AuthenticateRequest {
 
 message AuthenticateResponse {
   string token = 1;
-}
-
-message ListMyVotesRequest {
-  string snap_id_filter = 1;
-}
-
-message ListMyVotesResponse {
-  repeated Vote votes = 1;
 }
 
 message GetSnapVotesRequest {

--- a/src/grpc/user.rs
+++ b/src/grpc/user.rs
@@ -5,7 +5,7 @@ use crate::{
     proto::user::{
         user_server::{self, UserServer},
         AuthenticateRequest, AuthenticateResponse, GetSnapVotesRequest, GetSnapVotesResponse,
-        ListMyVotesRequest, ListMyVotesResponse, Vote as PbVote, VoteRequest,
+        Vote as PbVote, VoteRequest,
     },
     ratings::update_categories,
     Context,
@@ -97,36 +97,6 @@ impl user_server::User for UserService {
 
             Err(e) => {
                 error!("Error in save_vote_to_db: {:?}", e);
-                Err(Status::unknown("Internal server error"))
-            }
-        }
-    }
-
-    async fn list_my_votes(
-        &self,
-        mut request: Request<ListMyVotesRequest>,
-    ) -> Result<Response<ListMyVotesResponse>, Status> {
-        let Claims {
-            sub: client_hash, ..
-        } = claims(&mut request);
-
-        let ListMyVotesRequest { snap_id_filter } = request.into_inner();
-        let snap_id_filter = if snap_id_filter.is_empty() {
-            None
-        } else {
-            Some(snap_id_filter)
-        };
-
-        match Vote::get_all_by_client_hash(&client_hash, snap_id_filter, conn!()).await {
-            Ok(votes) => {
-                let votes = votes.into_iter().map(Into::into).collect();
-                let payload = ListMyVotesResponse { votes };
-
-                Ok(Response::new(payload))
-            }
-
-            Err(e) => {
-                error!("Error in find_user_votes: {:?}", e);
                 Err(Status::unknown("Internal server error"))
             }
         }

--- a/src/proto/ratings.features.user.rs
+++ b/src/proto/ratings.features.user.rs
@@ -14,18 +14,6 @@ pub struct AuthenticateResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ListMyVotesRequest {
-    #[prost(string, tag = "1")]
-    pub snap_id_filter: ::prost::alloc::string::String,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ListMyVotesResponse {
-    #[prost(message, repeated, tag = "1")]
-    pub votes: ::prost::alloc::vec::Vec<Vote>,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetSnapVotesRequest {
     #[prost(string, tag = "1")]
     pub snap_id: ::prost::alloc::string::String,
@@ -212,31 +200,6 @@ pub mod user_client {
                 .insert(GrpcMethod::new("ratings.features.user.User", "Vote"));
             self.inner.unary(req, path, codec).await
         }
-        pub async fn list_my_votes(
-            &mut self,
-            request: impl tonic::IntoRequest<super::ListMyVotesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListMyVotesResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/ratings.features.user.User/ListMyVotes",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("ratings.features.user.User", "ListMyVotes"));
-            self.inner.unary(req, path, codec).await
-        }
         pub async fn get_snap_votes(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSnapVotesRequest>,
@@ -286,13 +249,6 @@ pub mod user_server {
             &self,
             request: tonic::Request<super::VoteRequest>,
         ) -> std::result::Result<tonic::Response<()>, tonic::Status>;
-        async fn list_my_votes(
-            &self,
-            request: tonic::Request<super::ListMyVotesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListMyVotesResponse>,
-            tonic::Status,
-        >;
         async fn get_snap_votes(
             &self,
             request: tonic::Request<super::GetSnapVotesRequest>,
@@ -493,50 +449,6 @@ pub mod user_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = VoteSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/ratings.features.user.User/ListMyVotes" => {
-                    #[allow(non_camel_case_types)]
-                    struct ListMyVotesSvc<T: User>(pub Arc<T>);
-                    impl<T: User> tonic::server::UnaryService<super::ListMyVotesRequest>
-                    for ListMyVotesSvc<T> {
-                        type Response = super::ListMyVotesResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::ListMyVotesRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as User>::list_my_votes(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let inner = inner.0;
-                        let method = ListMyVotesSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(


### PR DESCRIPTION
This method is almost identical to `GetSnapVotes` (the difference being that the latter updates the categories in the db). Since it's not being used in the app-center, I think we can safely remove it.