### PR TITLE
feat: add `snap_name` to `Rating`  and `Vote` messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ skip_cache = []
 cached = { version = "0.54.0", features = ["async"] }
 dotenvy = "0.15"
 envy = "0.4"
+futures = "0.3"
 http = "1.1.0"
 jsonwebtoken = "9.2"
 prost = "0.13.3"

--- a/proto/ratings_features_common.proto
+++ b/proto/ratings_features_common.proto
@@ -6,6 +6,7 @@ message Rating {
   string snap_id = 1;
   uint64 total_votes = 2;
   RatingsBand ratings_band = 3;
+  string snap_name = 4;
 }
 
 enum RatingsBand {

--- a/proto/ratings_features_user.proto
+++ b/proto/ratings_features_user.proto
@@ -35,6 +35,7 @@ message Vote {
   int32 snap_revision = 2;
   bool vote_up = 3;
   google.protobuf.Timestamp timestamp = 4;
+  string snap_name = 5;
 }
 
 message VoteRequest {

--- a/src/grpc/app.rs
+++ b/src/grpc/app.rs
@@ -9,17 +9,21 @@ use crate::{
         common::Rating as PbRating,
     },
     ratings::Rating,
+    Context,
 };
+use std::sync::Arc;
 use tonic::{Request, Response, Status};
 use tracing::error;
 
 /// The general service governing retrieving ratings for the store app.
 #[derive(Clone)]
-pub struct RatingService;
+pub struct RatingService {
+    ctx: Arc<Context>,
+}
 
 impl RatingService {
-    pub fn new_server() -> AppServer<RatingService> {
-        AppServer::new(RatingService)
+    pub fn new_server(ctx: Arc<Context>) -> AppServer<RatingService> {
+        AppServer::new(RatingService { ctx })
     }
 }
 

--- a/src/grpc/app.rs
+++ b/src/grpc/app.rs
@@ -8,7 +8,7 @@ use crate::{
         },
         common::Rating as PbRating,
     },
-    ratings::Rating,
+    ratings::{get_snap_name, Rating},
     Context,
 };
 use std::sync::Arc;
@@ -46,11 +46,20 @@ impl App for RatingService {
                     ratings_band,
                 } = Rating::from(votes);
 
+                let snap_name = get_snap_name(
+                    &snap_id,
+                    &self.ctx.config.snapcraft_io_uri,
+                    &self.ctx.http_client,
+                )
+                .await
+                .map_err(|_| Status::unknown("Internal server error"))?;
+
                 Ok(Response::new(GetRatingResponse {
                     rating: Some(PbRating {
                         snap_id,
                         total_votes,
                         ratings_band: ratings_band as i32,
+                        snap_name,
                     }),
                 }))
             }

--- a/src/grpc/charts.rs
+++ b/src/grpc/charts.rs
@@ -66,7 +66,7 @@ impl chart_server::Chart for ChartService {
                         .await?;
 
                         Result::<PbChartData, Error>::Ok(
-                            PbChartData::from_chart_data_and_snap_name(chart_data, &snap_name),
+                            PbChartData::from_chart_data_and_snap_name(chart_data, snap_name),
                         )
                     }))
                     .await
@@ -106,7 +106,7 @@ async fn get_chart_cached(
 }
 
 impl PbChartData {
-    fn from_chart_data_and_snap_name(chart_data: ChartData, snap_name: &str) -> Self {
+    fn from_chart_data_and_snap_name(chart_data: ChartData, snap_name: String) -> Self {
         Self {
             raw_rating: chart_data.raw_rating,
             rating: Some(PbRating::from_rating_and_snap_name(
@@ -118,12 +118,12 @@ impl PbChartData {
 }
 
 impl PbRating {
-    fn from_rating_and_snap_name(rating: Rating, snap_name: &str) -> Self {
+    fn from_rating_and_snap_name(rating: Rating, snap_name: String) -> Self {
         Self {
             snap_id: rating.snap_id,
             total_votes: rating.total_votes,
             ratings_band: rating.ratings_band as i32,
-            snap_name: snap_name.into(),
+            snap_name,
         }
     }
 }

--- a/src/grpc/user.rs
+++ b/src/grpc/user.rs
@@ -7,9 +7,10 @@ use crate::{
         AuthenticateRequest, AuthenticateResponse, GetSnapVotesRequest, GetSnapVotesResponse,
         Vote as PbVote, VoteRequest,
     },
-    ratings::update_categories,
+    ratings::{get_snap_name, update_categories, Error},
     Context,
 };
+use futures::future::try_join_all;
 use std::sync::Arc;
 use time::OffsetDateTime;
 use tonic::{Request, Response, Status};
@@ -120,7 +121,18 @@ impl user_server::User for UserService {
 
         match Vote::get_all_by_client_hash(&client_hash, Some(snap_id), conn).await {
             Ok(votes) => {
-                let votes = votes.into_iter().map(|vote| vote.into()).collect();
+                let votes = try_join_all(votes.into_iter().map(|vote| async {
+                    let snap_name = get_snap_name(
+                        &vote.snap_id,
+                        &self.ctx.config.snapcraft_io_uri,
+                        &self.ctx.http_client,
+                    )
+                    .await?;
+
+                    Result::<PbVote, Error>::Ok(PbVote::from_vote_and_snap_name(vote, &snap_name))
+                }))
+                .await
+                .map_err(|_| Status::unknown("Internal server error"))?;
                 let payload = GetSnapVotesResponse { votes };
 
                 Ok(Response::new(payload))
@@ -134,8 +146,8 @@ impl user_server::User for UserService {
     }
 }
 
-impl From<Vote> for PbVote {
-    fn from(value: Vote) -> Self {
+impl PbVote {
+    fn from_vote_and_snap_name(value: Vote, snap_name: &str) -> Self {
         let timestamp = Some(prost_types::Timestamp {
             seconds: value.timestamp.unix_timestamp(),
             nanos: value.timestamp.nanosecond() as i32,
@@ -146,6 +158,7 @@ impl From<Vote> for PbVote {
             snap_revision: value.snap_revision as i32,
             vote_up: value.vote_up,
             timestamp,
+            snap_name: snap_name.into(),
         }
     }
 }

--- a/src/grpc/user.rs
+++ b/src/grpc/user.rs
@@ -25,8 +25,8 @@ pub struct UserService {
 }
 
 impl UserService {
-    pub fn new_server(ctx: Context) -> UserServer<UserService> {
-        UserServer::new(Self { ctx: Arc::new(ctx) })
+    pub fn new_server(ctx: Arc<Context>) -> UserServer<UserService> {
+        UserServer::new(Self { ctx })
     }
 }
 

--- a/src/proto/ratings.features.common.rs
+++ b/src/proto/ratings.features.common.rs
@@ -8,6 +8,8 @@ pub struct Rating {
     pub total_votes: u64,
     #[prost(enumeration = "RatingsBand", tag = "3")]
     pub ratings_band: i32,
+    #[prost(string, tag = "4")]
+    pub snap_name: ::prost::alloc::string::String,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/src/proto/ratings.features.user.rs
+++ b/src/proto/ratings.features.user.rs
@@ -35,6 +35,8 @@ pub struct Vote {
     pub vote_up: bool,
     #[prost(message, optional, tag = "4")]
     pub timestamp: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(string, tag = "5")]
+    pub snap_name: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/ratings/categories.rs
+++ b/src/ratings/categories.rs
@@ -83,10 +83,9 @@ async fn get_snap_categories(
     base: &str,
     client: &reqwest::Client,
 ) -> Result<Vec<Category>, Error> {
+    let snap_name = get_snap_name(snap_id, base, client).await?;
+
     let base_url = reqwest::Url::parse(base).map_err(|e| Error::InvalidUrl(e.to_string()))?;
-
-    let snap_name = get_snap_name(snap_id, &base_url, client).await?;
-
     let info_url = base_url
         .join(&format!("snaps/info/{snap_name}"))
         .map_err(|e| Error::InvalidUrl(e.to_string()))?;

--- a/src/ratings/categories.rs
+++ b/src/ratings/categories.rs
@@ -1,11 +1,10 @@
 //! Updating snap categories from data in snapcraft.io
 use crate::{
     db::{set_categories_for_snap, snap_has_categories, Category},
-    ratings::Error,
+    ratings::{get_json, get_snap_name, Error},
     Context,
 };
-use cached::proc_macro::cached;
-use serde::{de::DeserializeOwned, Deserialize};
+use serde::Deserialize;
 use sqlx::PgConnection;
 use std::sync::Arc;
 use tokio::sync::Notify;
@@ -78,26 +77,6 @@ async fn update_categories_inner(
     Ok(())
 }
 
-#[inline]
-async fn get_json<T: DeserializeOwned>(
-    url: reqwest::Url,
-    query: &[(&str, &str)],
-    client: &reqwest::Client,
-) -> Result<T, Error> {
-    let s = client
-        .get(url)
-        .header("User-Agent", "ratings-service")
-        .header("Snap-Device-Series", 16)
-        .query(query)
-        .send()
-        .await?
-        .error_for_status()?
-        .text()
-        .await?;
-
-    Ok(serde_json::from_str(&s)?)
-}
-
 /// Pull snap categories by for a given snapd_id from the snapcraft.io rest API
 async fn get_snap_categories(
     snap_id: &str,
@@ -138,43 +117,6 @@ async fn get_snap_categories(
     #[derive(Debug, Deserialize)]
     struct RawCategory {
         name: String,
-    }
-}
-
-#[cfg_attr(
-    not(feature = "skip_cache"),
-    cached(
-        key = "String",
-        convert = r##"{String::from(snap_id)}"##,
-        result = true
-    )
-)]
-async fn get_snap_name(
-    snap_id: &str,
-    base_url: &reqwest::Url,
-    client: &reqwest::Client,
-) -> Result<String, Error> {
-    let assertions_url = base_url
-        .join(&format!("assertions/snap-declaration/16/{snap_id}"))
-        .map_err(|e| Error::InvalidUrl(e.to_string()))?;
-
-    let AssertionsResp {
-        headers: Headers { snap_name },
-    } = get_json(assertions_url, &[], client).await?;
-
-    return Ok(snap_name);
-
-    // serde structs
-    //
-    #[derive(Debug, Deserialize)]
-    struct AssertionsResp {
-        headers: Headers,
-    }
-
-    #[derive(Debug, Deserialize)]
-    #[serde(rename_all = "kebab-case")]
-    struct Headers {
-        snap_name: String,
     }
 }
 

--- a/src/ratings/mod.rs
+++ b/src/ratings/mod.rs
@@ -3,9 +3,11 @@ mod categories;
 mod charts;
 mod rating;
 
+use cached::proc_macro::cached;
 pub use categories::update_categories;
 pub use charts::{Chart, ChartData};
 pub use rating::{calculate_band, Rating, RatingsBand};
+use serde::{de::DeserializeOwned, Deserialize};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -29,4 +31,61 @@ pub enum Error {
 
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+}
+
+#[inline]
+async fn get_json<T: DeserializeOwned>(
+    url: reqwest::Url,
+    query: &[(&str, &str)],
+    client: &reqwest::Client,
+) -> Result<T, Error> {
+    let s = client
+        .get(url)
+        .header("User-Agent", "ratings-service")
+        .header("Snap-Device-Series", 16)
+        .query(query)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    Ok(serde_json::from_str(&s)?)
+}
+
+#[cfg_attr(
+    not(feature = "skip_cache"),
+    cached(
+        key = "String",
+        convert = r##"{String::from(snap_id)}"##,
+        result = true
+    )
+)]
+async fn get_snap_name(
+    snap_id: &str,
+    base_url: &reqwest::Url,
+    client: &reqwest::Client,
+) -> Result<String, Error> {
+    let assertions_url = base_url
+        .join(&format!("assertions/snap-declaration/16/{snap_id}"))
+        .map_err(|e| Error::InvalidUrl(e.to_string()))?;
+
+    let AssertionsResp {
+        headers: Headers { snap_name },
+    } = get_json(assertions_url, &[], client).await?;
+
+    return Ok(snap_name);
+
+    // serde structs
+    //
+    #[derive(Debug, Deserialize)]
+    struct AssertionsResp {
+        headers: Headers,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "kebab-case")]
+    struct Headers {
+        snap_name: String,
+    }
 }

--- a/src/ratings/mod.rs
+++ b/src/ratings/mod.rs
@@ -63,9 +63,10 @@ async fn get_json<T: DeserializeOwned>(
 )]
 async fn get_snap_name(
     snap_id: &str,
-    base_url: &reqwest::Url,
+    base: &str,
     client: &reqwest::Client,
 ) -> Result<String, Error> {
+    let base_url = reqwest::Url::parse(base).map_err(|e| Error::InvalidUrl(e.to_string()))?;
     let assertions_url = base_url
         .join(&format!("assertions/snap-declaration/16/{snap_id}"))
         .map_err(|e| Error::InvalidUrl(e.to_string()))?;

--- a/src/ratings/mod.rs
+++ b/src/ratings/mod.rs
@@ -61,7 +61,7 @@ async fn get_json<T: DeserializeOwned>(
         result = true
     )
 )]
-async fn get_snap_name(
+pub(crate) async fn get_snap_name(
     snap_id: &str,
     base: &str,
     client: &reqwest::Client,


### PR DESCRIPTION
This adds `snap_name` to the `Rating` message which is part of `GetRatingResponse` and `GetChartResponse`. This spares us from having to resolve `snap_id`s into `snap_name`s in the app-center when requesting top charts from the server.

To simplify the transition from `snap_id`s to `snap_names` in the future, this also adds a `snap_name` field to the `Vote` message.

UDENG-5628