### PR TITLE
fix: use kebab-case for category deserialization

### DIFF
--- a/src/db/categories.rs
+++ b/src/db/categories.rs
@@ -14,6 +14,7 @@ use sqlx::{PgConnection, Postgres, QueryBuilder};
     strum::FromRepr,
 )]
 #[repr(i32)]
+#[strum(serialize_all = "kebab-case")]
 pub enum Category {
     ArtAndDesign = 0,
     BookAndReference = 1,


### PR DESCRIPTION
I noticed that `update_snap_categories` wasn't working when running the ratings server locally:
```
{"timestamp":"2024-12-13T11:31:42.208055Z","level":"ERROR","message":"unable to update snap categories: Matching variant not found","snap_id":"3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk","target":"ratings::ratings::categories","filename":"src/ratings/categories.rs","line_number":55,"threadId":"ThreadId(16)"}
```

The `get_snap_categories_works` test (which is skipped in CI since it's sending queries to snapcraft.io) was failing as well.