### PR TITLE
fix: handling the case where a snap has no categories

### DIFF
--- a/mock_server/src/main.rs
+++ b/mock_server/src/main.rs
@@ -56,7 +56,11 @@ async fn register_snap(
     categories: String,
 ) -> impl IntoResponse {
     info!("registering snap: {snap_id} -> {categories:?}");
-    let categories: Vec<String> = categories.split(',').map(|c| c.to_string()).collect();
+    let categories: Vec<String> = if !categories.is_empty() {
+        categories.split(',').map(|c| c.to_string()).collect()
+    } else {
+        vec![]
+    };
     let snap_name = Uuid::new_v4().to_string();
 
     let mut guard = state.write().unwrap();

--- a/src/db/categories.rs
+++ b/src/db/categories.rs
@@ -59,7 +59,6 @@ pub async fn set_categories_for_snap(
     query_builder.push_values(categories, |mut b, category| {
         b.push_bind(snap_id).push_bind(category);
     });
-    query_builder.push(";");
 
     query_builder.build().execute(conn).await?;
 

--- a/src/ratings/categories.rs
+++ b/src/ratings/categories.rs
@@ -72,7 +72,9 @@ async fn update_categories_inner(
     conn: &mut PgConnection,
 ) -> Result<(), Error> {
     let categories = get_snap_categories(snap_id, base, client).await?;
-    set_categories_for_snap(snap_id, categories, conn).await?;
+    if !categories.is_empty() {
+        set_categories_for_snap(snap_id, categories, conn).await?;
+    }
 
     Ok(())
 }

--- a/tests/voting.rs
+++ b/tests/voting.rs
@@ -98,3 +98,25 @@ async fn voting_updates_ratings_band(
 
     Ok(())
 }
+
+#[tokio::test]
+async fn voting_on_a_snap_without_categories_works() -> anyhow::Result<()> {
+    let t = TestHelper::new();
+
+    let user_token = t.authenticate(t.random_sha_256()).await?;
+    let snap_revision = 1;
+    let snap_id = t
+        .test_snap_with_initial_votes(snap_revision, 3, 2, &[])
+        .await?;
+
+    let initial_rating = t.get_rating(&snap_id, &user_token).await?;
+    assert_eq!(initial_rating.total_votes, 5, "initial total votes");
+
+    // Vote with a user who has not previously voted for this snap
+    t.vote(&snap_id, snap_revision, true, &user_token).await?;
+
+    let rating = t.get_rating(&snap_id, &user_token).await?;
+    assert_eq!(rating.total_votes, 6, "total votes: vote_up=true");
+
+    Ok(())
+}


### PR DESCRIPTION
It turns out that it is possible for snaps to have no associated categories:
```sh
curl -s \
  -H 'Snap-Device-Series: 16' \
  'https://api.snapcraft.io/v2/snaps/info/woe-usb?fields=categories' |
    jq '.snap'
{
  "categories": []
}
```