### PR TITLE
fix: attempting to set a pool idle timeout for connections to snapcraft.io

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use crate::{
     config::Config,
     jwt::{Error, JwtEncoder},
 };
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::sync::{Mutex, Notify};
 
 pub struct Context {
@@ -22,7 +22,9 @@ impl Context {
         Ok(Self {
             config,
             jwt_encoder,
-            http_client: reqwest::Client::new(),
+            http_client: reqwest::Client::builder()
+                .pool_idle_timeout(Duration::from_secs(5))
+                .build()?,
             category_updates: Default::default(),
         })
     }

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -27,6 +27,9 @@ pub enum Error {
     InvalidHeader,
 
     #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+
+    #[error(transparent)]
     TonicStatus(#[from] Status),
 }
 


### PR DESCRIPTION
We're seeing frequent errors from the deployed service when it is making requests to snapcraft.io that look like the following:
```
error sending request for url (...)
Caused by: client error (SendRequest)
Caused by: connection closed before message completed
```

https://github.com/hyperium/hyper/issues/2136 has details on the underlying source of the error and it looks like we need to reduce the default `pool_idle_timeout` from 90s to something much shorter. Initial local testing looks like we want to drop it all the way down to 5s which is what this PR is doing, but we probably want to tune this as we determine the performance implications.